### PR TITLE
Shaping Bricks' external interfaces.

### DIFF
--- a/cerealize/cerealize.h
+++ b/cerealize/cerealize.h
@@ -86,21 +86,14 @@ struct is_string_type {
 // Helper compile-time test that certain type can be serialized via cereal.
 template <typename T>
 struct is_read_cerealizable {
-  // Cereal _might_ have an issue with `<T&>` not being treated as input-serealizable.
-  // (I'd assume no const is expected for input serialization -- D.K.)
   constexpr static bool value = !is_string_type<T>::value &&
-                                cereal::traits::is_input_serializable<typename std::remove_reference<T>::type,
-                                                                      cereal::JSONInputArchive>::value;
+                                cereal::traits::is_input_serializable<T, cereal::JSONInputArchive>::value;
 };
 
 template <typename T>
 struct is_write_cerealizable {
-  // Cereal has an issue with `<const T&>` not being treated as output-serealizable.
-  // I reported it as https://github.com/USCiLab/cereal/issues/171 -- D.K.
-  constexpr static bool value = !is_string_type<T>::value &&
-                                cereal::traits::is_output_serializable<
-                                    typename std::remove_const<typename std::remove_reference<T>::type>::type,
-                                    cereal::JSONOutputArchive>::value;
+  constexpr static bool value =
+      !is_string_type<T>::value && cereal::traits::is_output_serializable<T, cereal::JSONOutputArchive>::value;
 };
 
 template <typename T>

--- a/cerealize/cerealize.h
+++ b/cerealize/cerealize.h
@@ -86,8 +86,8 @@ struct is_string_type {
 // Helper compile-time test that certain type can be serialized via cereal.
 template <typename T>
 struct is_read_cerealizable {
-  constexpr static bool value = !is_string_type<T>::value &&
-                                cereal::traits::is_input_serializable<T, cereal::JSONInputArchive>::value;
+  constexpr static bool value =
+      !is_string_type<T>::value && cereal::traits::is_input_serializable<T, cereal::JSONInputArchive>::value;
 };
 
 template <typename T>

--- a/cerealize/cerealize.h
+++ b/cerealize/cerealize.h
@@ -52,19 +52,27 @@ struct is_string_type_impl {
   constexpr static bool value = false;
 };
 template <>
-struct is_string_type_impl<const std::string> {
+struct is_string_type_impl<std::string> {
   constexpr static bool value = true;
 };
 template <>
-struct is_string_type_impl<const std::vector<char>> {
+struct is_string_type_impl<std::vector<char>> {
   constexpr static bool value = true;
 };
 template <>
-struct is_string_type_impl<const std::vector<int8_t>> {
+struct is_string_type_impl<std::vector<int8_t>> {
   constexpr static bool value = true;
 };
 template <>
-struct is_string_type_impl<const std::vector<uint8_t>> {
+struct is_string_type_impl<std::vector<uint8_t>> {
+  constexpr static bool value = true;
+};
+template <>
+struct is_string_type_impl<char*> {
+  constexpr static bool value = true;
+};
+template <size_t N>
+struct is_string_type_impl<char[N]> {
   constexpr static bool value = true;
 };
 template <>
@@ -79,8 +87,8 @@ struct is_string_type_impl<const char[N]> {
 // explicitly exclude string-related types from cereal-based implementations.
 template <typename TOP_LEVEL_T>
 struct is_string_type {
-  constexpr static bool value =
-      is_string_type_impl<const typename std::remove_reference<TOP_LEVEL_T>::type>::value;
+  constexpr static bool value = is_string_type_impl<
+      typename std::remove_cv<typename std::remove_reference<TOP_LEVEL_T>::type>::type>::value;
 };
 
 // Helper compile-time test that certain type can be serialized via cereal.

--- a/cerealize/cerealize.h
+++ b/cerealize/cerealize.h
@@ -29,6 +29,8 @@ SOFTWARE.
 #include <string>
 #include <sstream>
 
+#include "exceptions.h"
+
 #include "../3party/cereal/include/types/string.hpp"
 #include "../3party/cereal/include/types/vector.hpp"
 #include "../3party/cereal/include/types/map.hpp"
@@ -268,6 +270,62 @@ inline std::string JSON(T&& object, S&& name) {
   std::ostringstream os;
   AppendAsJSON(os, std::forward<T>(object), name);
   return os.str();
+}
+
+// JSON parse error handling logic.
+// By default, an exception is thrown.
+// If a user class defines the `FromInvalidJSON()` method, JSONParse() is a non-throwing call,
+// and that method will be called instead.
+
+template <typename T>
+struct HasFromInvalidJSON {
+  typedef char one;
+  typedef long two;
+
+  template <typename C>
+  static one test(decltype(&C::FromInvalidJSON));
+  template <typename C>
+  static two test(...);
+
+  constexpr static bool value = (sizeof(test<T>(0)) == sizeof(one));
+};
+
+template <typename T, bool B>
+struct BricksJSONParseError {};
+
+template <typename T>
+struct BricksJSONParseError<T, false> {
+  static void HandleJSONParseError(const std::string& input_json, T&) {
+    throw bricks::JSONParseException(input_json);
+  }
+};
+
+template <typename T>
+struct BricksJSONParseError<T, true> {
+  static void HandleJSONParseError(const std::string& input_json, T& output_object) {
+    output_object.FromInvalidJSON(input_json);
+  }
+};
+
+template <typename T>
+inline const T& JSONParse(const std::string& input_json, T& output_object) {
+  try {
+    std::istringstream is(input_json);
+    cereal::JSONInputArchive ar(is);
+    ar(output_object);
+  } catch (cereal::Exception&) {
+    BricksJSONParseError<T, HasFromInvalidJSON<typename std::remove_reference<T>::type>::value>::
+        HandleJSONParseError(input_json, output_object);
+  }
+  return output_object;
+}
+
+template <typename T>
+inline T JSONParse(const std::string& input_json) {
+  T placeholder;
+  JSONParse(input_json, placeholder);
+  // Can not just do `return JSONParse()`, since it would not handle ownership transfer for `std::unique_ptr<>`.
+  return placeholder;
 }
 
 }  // namespace cerealize

--- a/cerealize/cerealize.h
+++ b/cerealize/cerealize.h
@@ -96,6 +96,7 @@ struct is_read_cerealizable {
 template <typename T>
 struct is_write_cerealizable {
   // Cereal has an issue with `<const T&>` not being treated as output-serealizable.
+  // I reported it as https://github.com/USCiLab/cereal/issues/171 -- D.K.
   constexpr static bool value = !is_string_type<T>::value &&
                                 cereal::traits::is_output_serializable<
                                     typename std::remove_const<typename std::remove_reference<T>::type>::type,

--- a/cerealize/exceptions.h
+++ b/cerealize/exceptions.h
@@ -1,0 +1,38 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2014 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BRICKS_CEREALIZE_EXCEPTIONS_H
+#define BRICKS_CEREALIZE_EXCEPTIONS_H
+
+#include "../exception.h"
+
+namespace bricks {
+
+struct JSONParseException : Exception {
+  explicit JSONParseException(const std::string& input) : Exception("Invalid JSON:\n" + input) {}
+};
+
+}  // namespace bricks
+
+#endif  // BRICKS_CEREALIZE_EXCEPTIONS_H

--- a/cerealize/test/impl.cc
+++ b/cerealize/test/impl.cc
@@ -71,10 +71,39 @@ struct Yes {
   void serialize(A&) {}
 };
 
-TEST(Cerealize, CompileTimeTest) {
-  EXPECT_FALSE(is_cerealizable<No>::value);
-  EXPECT_TRUE(is_cerealizable<Yes>::value);
-};
+TEST(Cerealize, CompileTimeTests) {
+  static_assert(!is_cerealizable<No>::value, "");
+  static_assert(is_cerealizable<Yes>::value, "");
+
+  static_assert(!is_string_type<int>::value, "");
+
+  static_assert(is_string_type<char*>::value, "");
+
+  static_assert(is_string_type<const char*>::value, "");
+  static_assert(is_string_type<const char*&>::value, "");
+  static_assert(is_string_type<const char*&&>::value, "");
+  static_assert(is_string_type<char*&&>::value, "");
+
+  static_assert(is_string_type<std::string>::value, "");
+  static_assert(is_string_type<const std::string&>::value, "");
+  static_assert(is_string_type<std::string&&>::value, "");
+
+  static_assert(is_string_type<std::vector<char>>::value, "");
+  static_assert(is_string_type<const std::vector<char>&>::value, "");
+  static_assert(is_string_type<std::vector<char>&&>::value, "");
+
+  static_assert(!is_write_cerealizable<const char*>::value, "");
+  static_assert(!is_write_cerealizable<const char*&>::value, "");
+  static_assert(!is_write_cerealizable<const char*&&>::value, "");
+
+  static_assert(!is_write_cerealizable<char*>::value, "");
+  static_assert(!is_write_cerealizable<char*&>::value, "");
+  static_assert(!is_write_cerealizable<char*&&>::value, "");
+
+  static_assert(!is_write_cerealizable<std::vector<char>>::value, "");
+  static_assert(!is_write_cerealizable<const std::vector<char>&>::value, "");
+  static_assert(!is_write_cerealizable<std::vector<char>&&>::value, "");
+}
 
 struct CerealTestObject {
   int number;
@@ -89,12 +118,12 @@ struct CerealTestObject {
 
 TEST(Cerealize, JSON) {
   EXPECT_EQ("{\"value0\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}", JSON(CerealTestObject()));
-};
+}
 
 TEST(Cerealize, NamedJSON) {
   EXPECT_EQ("{\"BAZINGA\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}",
             JSON(CerealTestObject(), "BAZINGA"));
-};
+}
 
 TEST(Cerealize, BinarySerializesAndParses) {
   FileSystem::MkDir(FLAGS_cerealize_test_tmpdir, FileSystem::MkDirParameters::Silent);

--- a/cerealize/test/impl.cc
+++ b/cerealize/test/impl.cc
@@ -43,14 +43,19 @@ SOFTWARE.
 
 #include "../../file/file.h"
 
+#include "../../strings/printf.h"
+
 #include "../../dflags/dflags.h"
 #include "../../3party/gtest/gtest-main-with-dflags.h"
 
 using namespace bricks;
 using namespace cerealize;
 
+using strings::Printf;
+
 DEFINE_string(cerealize_test_tmpdir, ".noshit", "The directory to create temporary files in.");
 
+// TODO(dkorolev): Move this helper into 3party/gtest/ ?
 static std::string CurrentTestName() {
   // via https://code.google.com/p/googletest/wiki/AdvancedGuide#Getting_the_Current_Test%27s_Name
   return ::testing::UnitTest::GetInstance()->current_test_info()->name();
@@ -218,4 +223,111 @@ TEST(Cerealize, ConsumerSupportsPolymorphicTypes) {
       "Type=EventAppResume, ShortType=\"ar\","
       " UID=, UID_Google=, UID_Apple=, UID_Facebook=, baz=baz RESUME \n",
       consumer.os.str());
+}
+
+// CT stands for CerealizeTest.
+// Global symbol names should be unique since all the tests are compiled together for the coverage report.
+struct CTBase {
+  int number = 0;
+  template <class A>
+  void serialize(A& ar) {
+    ar(CEREAL_NVP(number));
+  }
+  virtual std::string AsString() const = 0;
+};
+
+struct CTDerived1 : CTBase {
+  std::string foo;
+  template <class A>
+  void serialize(A& ar) {
+    CTBase::serialize(ar);
+    ar(CEREAL_NVP(foo));
+  }
+  virtual std::string AsString() const override { return Printf("Derived1(%d,'%s')", number, foo.c_str()); }
+};
+CEREAL_REGISTER_TYPE(CTDerived1);
+
+struct CTDerived2 : CTBase {
+  std::string bar;
+  template <class A>
+  void serialize(A& ar) {
+    CTBase::serialize(ar);
+    ar(CEREAL_NVP(bar));
+  }
+  virtual std::string AsString() const override { return Printf("Derived2(%d,'%s')", number, bar.c_str()); }
+  void FromInvalidJSON(const std::string& input_json) {
+    number = -1;
+    bar = "Invalid JSON: " + input_json;
+  }
+};
+CEREAL_REGISTER_TYPE(CTDerived2);
+
+static_assert(!HasFromInvalidJSON<CTDerived1>::value, "");
+static_assert(HasFromInvalidJSON<CTDerived2>::value, "");
+
+TEST(Cerealize, JSONStringifyWithBase) {
+  CTDerived1 d1;
+  d1.foo = "fffuuuuu";
+  EXPECT_EQ("{\"value0\":{\"number\":0,\"foo\":\"fffuuuuu\"}}", JSON(d1));
+  EXPECT_EQ(
+      "{\"value0\":{\"polymorphic_id\":2147483649,\"polymorphic_name\":\"CTDerived1\","
+      "\"ptr_wrapper\":{\"valid\":1,\"data\":{\"number\":0,\"foo\":\"fffuuuuu\"}}}}",
+      JSON(WithBaseType<CTBase>(d1)));
+
+  CTDerived2 d2;
+  d2.bar = "bwahaha";
+  EXPECT_EQ("{\"value0\":{\"number\":0,\"bar\":\"bwahaha\"}}", JSON(d2));
+  EXPECT_EQ(
+      "{\"value0\":{\"polymorphic_id\":2147483649,\"polymorphic_name\":\"CTDerived2\","
+      "\"ptr_wrapper\":{\"valid\":1,\"data\":{\"number\":0,\"bar\":\"bwahaha\"}}}}",
+      JSON(WithBaseType<CTBase>(d2)));
+}
+
+TEST(Cerealize, ParseJSONReturnValueSyntax) {
+  CTDerived1 input;
+  input.number = 42;
+  input.foo = "string";
+  CTDerived1 output = JSONParse<CTDerived1>(JSON(input));
+  EXPECT_EQ(42, output.number);
+  EXPECT_EQ("string", output.foo);
+}
+
+TEST(Cerealize, ParseJSONReferenceSyntax) {
+  CTDerived1 input;
+  input.number = 42;
+  input.foo = "string";
+  CTDerived1 output;
+  JSONParse(JSON(input), output);
+  EXPECT_EQ(42, output.number);
+  EXPECT_EQ("string", output.foo);
+}
+
+TEST(Cerealize, ParseJSONSupportsPolymorphicTypes) {
+  CTDerived1 d1;
+  d1.number = 1;
+  d1.foo = "foo";
+  CTDerived2 d2;
+  d2.number = 2;
+  d2.bar = "bar";
+
+  {
+    EXPECT_EQ("Derived1(1,'foo')",
+              JSONParse<std::unique_ptr<CTBase>>(JSON(WithBaseType<CTBase>(d1)))->AsString());
+    EXPECT_EQ("Derived2(2,'bar')",
+              JSONParse<std::unique_ptr<CTBase>>(JSON(WithBaseType<CTBase>(d2)))->AsString());
+  }
+
+  {
+    std::unique_ptr<CTBase> placeholder;
+    EXPECT_EQ("Derived1(1,'foo')", JSONParse(JSON(WithBaseType<CTBase>(d1)), placeholder)->AsString());
+    EXPECT_EQ("Derived2(2,'bar')", JSONParse(JSON(WithBaseType<CTBase>(d2)), placeholder)->AsString());
+  }
+}
+
+TEST(Cerealize, ParseJSONThrowsOnError) {
+  ASSERT_THROW(JSONParse<CTDerived1>("surely not a valid JSON"), JSONParseException);
+}
+
+TEST(Cerealize, ParseJSONErrorCanBeMadeNonThrowing) {
+  EXPECT_EQ("Derived2(-1,'Invalid JSON: BAZINGA')", JSONParse<CTDerived2>("BAZINGA").AsString());
 }

--- a/file/file.h
+++ b/file/file.h
@@ -52,7 +52,7 @@ namespace bricks {
 // Platform-indepenent, injection-friendly filesystem wrapper.
 // TODO(dkorolev): Move the above methods under FileSystem.
 struct FileSystem {
-  static std::string GetFileExtension(const std::string& file_name) {
+  static inline std::string GetFileExtension(const std::string& file_name) {
     const static auto get_extension_from_basename = [](const std::string& fn) {
       const size_t i = fn.find_last_of('.');
       return i == std::string::npos ? "" : fn.substr(i + 1);

--- a/file/file.h
+++ b/file/file.h
@@ -52,7 +52,24 @@ namespace bricks {
 // Platform-indepenent, injection-friendly filesystem wrapper.
 // TODO(dkorolev): Move the above methods under FileSystem.
 struct FileSystem {
-  static inline std::string ReadFileAsString(std::string const& file_name) {
+  static std::string GetFileExtension(const std::string& file_name) {
+    const static auto get_extension_from_basename = [](const std::string& fn) {
+      const size_t i = fn.find_last_of('.');
+      return i == std::string::npos ? "" : fn.substr(i + 1);
+    };  // LCOV_EXCL_LINE
+
+    static_assert(std::string::npos + 1 == 0, "This invariant is used in the next line.");
+    const size_t basename_offset = file_name.find_last_of("/\\") + 1;
+
+    if (!basename_offset) {
+      return get_extension_from_basename(file_name);
+    } else {
+      // Unfortunately, `std::string::find_last_of()` accepts index to stop at, not index to start form.
+      return get_extension_from_basename(file_name.substr(basename_offset));
+    }
+  }
+
+  static inline std::string ReadFileAsString(const std::string& file_name) {
     try {
       std::ifstream fi;
       fi.exceptions(std::ifstream::failbit | std::ifstream::badbit);

--- a/file/file.h
+++ b/file/file.h
@@ -53,19 +53,11 @@ namespace bricks {
 // TODO(dkorolev): Move the above methods under FileSystem.
 struct FileSystem {
   static inline std::string GetFileExtension(const std::string& file_name) {
-    const static auto get_extension_from_basename = [](const std::string& fn) {
-      const size_t i = fn.find_last_of('.');
-      return i == std::string::npos ? "" : fn.substr(i + 1);
-    };  // LCOV_EXCL_LINE
-
-    static_assert(std::string::npos + 1 == 0, "This invariant is used in the next line.");
-    const size_t basename_offset = file_name.find_last_of("/\\") + 1;
-
-    if (!basename_offset) {
-      return get_extension_from_basename(file_name);
+    const size_t i = file_name.find_last_of("/\\.");
+    if (i == std::string::npos || file_name[i] != '.') {
+      return "";
     } else {
-      // Unfortunately, `std::string::find_last_of()` accepts index to stop at, not index to start form.
-      return get_extension_from_basename(file_name.substr(basename_offset));
+      return file_name.substr(i + 1);
     }
   }
 

--- a/file/test.cc
+++ b/file/test.cc
@@ -49,6 +49,24 @@ TEST(File, JoinPath) {
   ASSERT_THROW(FileSystem::JoinPath("/foo/", ""), FileException);
 }
 
+TEST(File, GetFileExtension) {
+  EXPECT_EQ("", FileSystem::GetFileExtension(""));
+  EXPECT_EQ("", FileSystem::GetFileExtension("a"));
+  EXPECT_EQ("b", FileSystem::GetFileExtension("a.b"));
+  EXPECT_EQ("c", FileSystem::GetFileExtension("a.b.c"));
+  EXPECT_EQ("a", FileSystem::GetFileExtension(".a"));
+  EXPECT_EQ("a", FileSystem::GetFileExtension("..a"));
+  EXPECT_EQ("", FileSystem::GetFileExtension("a/b"));
+  EXPECT_EQ("b", FileSystem::GetFileExtension("a/.b"));
+  EXPECT_EQ("", FileSystem::GetFileExtension("a/b/c"));
+  EXPECT_EQ("c", FileSystem::GetFileExtension("a/b/.c"));
+  EXPECT_EQ("a", FileSystem::GetFileExtension(".a"));
+  EXPECT_EQ("", FileSystem::GetFileExtension("./a"));
+  EXPECT_EQ("", FileSystem::GetFileExtension("../a"));
+  EXPECT_EQ("a", FileSystem::GetFileExtension("../.a"));
+  EXPECT_EQ("long_extension", FileSystem::GetFileExtension("long_name.long_extension"));
+}
+
 TEST(File, FileStringOperations) {
   const std::string fn = FileSystem::JoinPath(FLAGS_file_test_tmpdir, "tmp");
 

--- a/net/Makefile
+++ b/net/Makefile
@@ -1,7 +1,7 @@
-.PHONY: test indent clean check coverage
+.PHONY: default indent clean check coverage
 
-test:
-	(cd url; make test) && (cd tcp; make test) && (cd http; make test) && (cd api; make test) && echo "ALL TESTS PASS"
+default:
+	(cd url; make default) && (cd tcp; make default) && (cd http; make default) && (cd api; make default) && echo "ALL TESTS PASS"
 
 indent:
 	(find . -name "*.cc" ; find . -name "*.h") | xargs clang-format-3.5 -i

--- a/net/api/api.h
+++ b/net/api/api.h
@@ -75,24 +75,15 @@ namespace bricks {
 namespace net {
 namespace api {
 
-// A small helper to hint compiler which type to deduce in the `decltype`-s below.
-namespace impl {
-template <typename T>
-inline T TypeHelper() {
-  static T* never_used_helper_ptr;
-  return *never_used_helper_ptr;
-}
-}  // namespace impl
-
 // Allow `HTTP(GET(url))` and other `HTTP(...)` syntaxes, assuming `using bricks::net::api`.
 template <typename T1>
-inline decltype(Singleton<HTTP_IMPL>()(impl::TypeHelper<T1>())) HTTP(T1&& p1) {
+inline decltype(Singleton<HTTP_IMPL>()(std::declval<T1>())) HTTP(T1&& p1) {
   return Singleton<HTTP_IMPL>()(std::forward<T1>(p1));
 }
 
 // Allow `HTTP(POST(url, data))` and other `HTTP(..., ...)` syntaxes, assuming `using bricks::net::api`.
 template <typename T1, typename T2>
-inline decltype(Singleton<HTTP_IMPL>()(impl::TypeHelper<T1>(), impl::TypeHelper<T2>())) HTTP(T1&& p1, T2&& p2) {
+inline decltype(Singleton<HTTP_IMPL>()(std::declval<T1>(), std::declval<T2>())) HTTP(T1&& p1, T2&& p2) {
   return Singleton<HTTP_IMPL>()(std::forward<T1>(p1), std::forward<T2>(p2));
 }
 

--- a/net/api/chunked_demo.cc
+++ b/net/api/chunked_demo.cc
@@ -111,7 +111,7 @@ using namespace bricks::cerealize;
 using bricks::time::Now;
 using bricks::strings::Printf;
 using bricks::net::HTTPResponseCode;
-using bricks::net::HTTPHeadersType;
+using bricks::net::HTTPHeaders;
 
 DEFINE_int32(port, 8181, "The port to serve chunked response on.");
 
@@ -183,14 +183,14 @@ int main() {
       "layout",
       HTTPResponseCode::OK,
       "application/json; charset=utf-8",
-      HTTPHeadersType({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
+      HTTPHeaders({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
   });
   HTTP(FLAGS_port).Register("/meta", [](Request r) {
     r(ExampleMeta(),
       "meta",
       HTTPResponseCode::OK,
       "application/json; charset=utf-8",
-      HTTPHeadersType({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
+      HTTPHeaders({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
   });
   HTTP(FLAGS_port).Register("/data", [](Request r) {
     std::thread([](Request&& r) {

--- a/net/api/chunked_demo.cc
+++ b/net/api/chunked_demo.cc
@@ -111,6 +111,7 @@ using namespace bricks::cerealize;
 using bricks::time::Now;
 using bricks::strings::Printf;
 using bricks::net::HTTPResponseCode;
+using bricks::net::HTTPHeadersType;
 
 DEFINE_int32(port, 8181, "The port to serve chunked response on.");
 
@@ -174,24 +175,24 @@ struct ExampleMeta {
 
 // TODO(dkorolev): Finish multithreading. Need to notify active connections and wait for them to finish.
 int main() {
-  HTTP(FLAGS_port).Register("/layout", [](Request&& r) {
+  HTTP(FLAGS_port).Register("/layout", [](Request r) {
     LayoutItem layout;
     LayoutItem row;
     layout.col.push_back(row);
-    r.connection.SendHTTPResponse(layout,
-                                  "layout",
-                                  HTTPResponseCode::OK,
-                                  "application/json; charset=utf-8",
-                                  {{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}});
+    r(layout,
+      "layout",
+      HTTPResponseCode::OK,
+      "application/json; charset=utf-8",
+      HTTPHeadersType({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
   });
-  HTTP(FLAGS_port).Register("/meta", [](Request&& r) {
-    r.connection.SendHTTPResponse(ExampleMeta(),
-                                  "meta",
-                                  HTTPResponseCode::OK,
-                                  "application/json; charset=utf-8",
-                                  {{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}});
+  HTTP(FLAGS_port).Register("/meta", [](Request r) {
+    r(ExampleMeta(),
+      "meta",
+      HTTPResponseCode::OK,
+      "application/json; charset=utf-8",
+      HTTPHeadersType({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
   });
-  HTTP(FLAGS_port).Register("/data", [](Request&& r) {
+  HTTP(FLAGS_port).Register("/data", [](Request r) {
     std::thread([](Request&& r) {
                   // Since we are in another thread, need to catch exceptions ourselves.
                   try {

--- a/net/api/impl/posix_server.h
+++ b/net/api/impl/posix_server.h
@@ -76,6 +76,30 @@ struct Request final {
         http(unique_connection->HTTPRequest()),
         url(http.URL()) {}
 
+  // A shortcut to allow `[](Request r) { r("OK"); }` instead of `r.connection.SendHTTPResponse("OK")`.
+  // TODO(dkorolev): I could not make <typename... ARGS> work here. Investigate further?
+  // TODO(dkorolev): I could not make these calls support initilizer lists. Investigate further?
+  template <typename T1>
+  void operator()(const T1& p1) {
+    connection.SendHTTPResponse(p1);
+  }
+  template <typename T1, typename T2>
+  void operator()(const T1& p1, const T2& p2) {
+    connection.SendHTTPResponse(p1, p2);
+  }
+  template <typename T1, typename T2, typename T3>
+  void operator()(const T1& p1, const T2& p2, const T3& p3) {
+    connection.SendHTTPResponse(p1, p2, p3);
+  }
+  template <typename T1, typename T2, typename T3, typename T4>
+  void operator()(const T1& p1, const T2& p2, const T3& p3, const T4& p4) {
+    connection.SendHTTPResponse(p1, p2, p3, p4);
+  }
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  void operator()(const T1& p1, const T2& p2, const T3& p3, const T4& p4, const T5& p5) {
+    connection.SendHTTPResponse(p1, p2, p3, p4, p5);
+  }
+
   Request() = delete;
   Request(const Request&) = delete;
   void operator=(const Request&) = delete;

--- a/net/api/impl/posix_server.h
+++ b/net/api/impl/posix_server.h
@@ -78,7 +78,7 @@ struct Request final {
 
   // A shortcut to allow `[](Request r) { r("OK"); }` instead of `r.connection.SendHTTPResponse("OK")`.
   // TODO(dkorolev): I could not make <typename... ARGS> work here. Investigate further?
-  // TODO(dkorolev): I could not make these calls support initilizer lists. Investigate further?
+  // TODO(dkorolev): I could not make these calls support initializer lists. Investigate further?
   template <typename T1>
   void operator()(const T1& p1) {
     connection.SendHTTPResponse(p1);

--- a/net/api/impl/posix_server.h
+++ b/net/api/impl/posix_server.h
@@ -80,23 +80,23 @@ struct Request final {
   // TODO(dkorolev): I could not make <typename... ARGS> work here. Investigate further?
   // TODO(dkorolev): I could not make these calls support initializer lists. Investigate further?
   template <typename T1>
-  void operator()(const T1& p1) {
+  void operator()(T1&& p1) {
     connection.SendHTTPResponse(p1);
   }
   template <typename T1, typename T2>
-  void operator()(const T1& p1, const T2& p2) {
+  void operator()(T1&& p1, T2&& p2) {
     connection.SendHTTPResponse(p1, p2);
   }
   template <typename T1, typename T2, typename T3>
-  void operator()(const T1& p1, const T2& p2, const T3& p3) {
+  void operator()(T1&& p1, T2&& p2, T3&& p3) {
     connection.SendHTTPResponse(p1, p2, p3);
   }
   template <typename T1, typename T2, typename T3, typename T4>
-  void operator()(const T1& p1, const T2& p2, const T3& p3, const T4& p4) {
+  void operator()(T1&& p1, T2&& p2, T3&& p3, T4&& p4) {
     connection.SendHTTPResponse(p1, p2, p3, p4);
   }
   template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  void operator()(const T1& p1, const T2& p2, const T3& p3, const T4& p4, const T5& p5) {
+  void operator()(T1&& p1, T2&& p2, T3&& p3, T4&& p4, T5&& p5) {
     connection.SendHTTPResponse(p1, p2, p3, p4, p5);
   }
 

--- a/net/api/test.cc
+++ b/net/api/test.cc
@@ -322,7 +322,7 @@ TEST(HTTPAPI, RespondWithStringAsString) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   HTTP(FLAGS_net_api_test_port).Register("/respond_with_std_string", [](Request r) {
     ASSERT_FALSE(r.http.HasBody());
-    r.connection.SendHTTPResponse(std::string("std::string"), HTTPResponseCode::InternalServerError);
+    r.connection.SendHTTPResponse(std::string("std::string"), HTTPResponseCode::OK);
   });
   EXPECT_EQ("std::string",
             HTTP(POST(Printf("localhost:%d/respond_with_std_string", FLAGS_net_api_test_port))).body);
@@ -333,7 +333,7 @@ TEST(HTTPAPI, RespondWithStringAsConstCharPtr) {
   HTTP(FLAGS_net_api_test_port).Register("/respond_with_const_char_ptr", [](Request r) {
     ASSERT_FALSE(r.http.HasBody());
     r.connection.SendHTTPResponse(static_cast<const char*>("const char*"),
-                                  HTTPResponseCode::InternalServerError);
+                                  HTTPResponseCode::OK);
   });
   EXPECT_EQ("const char*",
             HTTP(POST(Printf("localhost:%d/respond_with_const_char_ptr", FLAGS_net_api_test_port))).body);
@@ -343,7 +343,7 @@ TEST(HTTPAPI, RespondWithStringAsStringViaRequestDirectly) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   HTTP(FLAGS_net_api_test_port).Register("/respond_with_std_string_via_request_directly", [](Request r) {
     ASSERT_FALSE(r.http.HasBody());
-    r(std::string("std::string"), HTTPResponseCode::InternalServerError);
+    r(std::string("std::string"), HTTPResponseCode::OK);
   });
   EXPECT_EQ("std::string",
             HTTP(POST(Printf("localhost:%d/respond_with_std_string_via_request_directly",
@@ -354,7 +354,7 @@ TEST(HTTPAPI, RespondWithStringAsConstCharPtrViaRequestDirectly) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   HTTP(FLAGS_net_api_test_port).Register("/respond_with_const_char_ptr_via_request_directly", [](Request r) {
     ASSERT_FALSE(r.http.HasBody());
-    r(static_cast<const char*>("const char*"), HTTPResponseCode::InternalServerError);
+    r(static_cast<const char*>("const char*"), HTTPResponseCode::OK);
   });
   EXPECT_EQ("const char*",
             HTTP(POST(Printf("localhost:%d/respond_with_const_char_ptr_via_request_directly",

--- a/net/api/test.cc
+++ b/net/api/test.cc
@@ -44,7 +44,7 @@ using bricks::FileException;
 
 using bricks::net::Connection;
 using bricks::net::HTTPResponseCode;
-using bricks::net::HTTPHeadersType;
+using bricks::net::HTTPHeaders;
 
 using bricks::net::HTTPRedirectNotAllowedException;
 using bricks::net::HTTPRedirectLoopException;
@@ -107,7 +107,7 @@ TEST(HTTPAPI, URLParameters) {
 TEST(HTTPAPI, Redirect) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   HTTP(FLAGS_net_api_test_port).Register("/from", [](Request r) {
-    r("", HTTPResponseCode::Found, "text/html", HTTPHeadersType({{"Location", "/to"}}));
+    r("", HTTPResponseCode::Found, "text/html", HTTPHeaders({{"Location", "/to"}}));
   });
   HTTP(FLAGS_net_api_test_port).Register("/to", [](Request r) { r("Done."); });
   // Redirect not allowed by default.
@@ -123,13 +123,13 @@ TEST(HTTPAPI, Redirect) {
 TEST(HTTPAPI, RedirectLoop) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   HTTP(FLAGS_net_api_test_port).Register("/p1", [](Request r) {
-    r("", HTTPResponseCode::Found, "text/html", HTTPHeadersType({{"Location", "/p2"}}));
+    r("", HTTPResponseCode::Found, "text/html", HTTPHeaders({{"Location", "/p2"}}));
   });
   HTTP(FLAGS_net_api_test_port).Register("/p2", [](Request r) {
-    r("", HTTPResponseCode::Found, "text/html", HTTPHeadersType({{"Location", "/p3"}}));
+    r("", HTTPResponseCode::Found, "text/html", HTTPHeaders({{"Location", "/p3"}}));
   });
   HTTP(FLAGS_net_api_test_port).Register("/p3", [](Request r) {
-    r("", HTTPResponseCode::Found, "text/html", HTTPHeadersType({{"Location", "/p1"}}));
+    r("", HTTPResponseCode::Found, "text/html", HTTPHeaders({{"Location", "/p1"}}));
   });
   ASSERT_THROW(HTTP(GET(Printf("localhost:%d/p1", FLAGS_net_api_test_port))), HTTPRedirectLoopException);
 }

--- a/net/api/test.cc
+++ b/net/api/test.cc
@@ -244,6 +244,15 @@ TEST(HTTPAPI, PostFromBufferToBuffer) {
   EXPECT_EQ("Data: No shit!", response.body);
 }
 
+TEST(HTTPAPI, PostWithEmptyBody) {
+  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
+  HTTP(FLAGS_net_api_test_port).Register("/post", [](Request r) {
+    ASSERT_FALSE(r.http.HasBody());
+    r.connection.SendHTTPResponse("Empty POST.");
+  });
+  EXPECT_EQ("Empty POST.", HTTP(POST(Printf("localhost:%d/post", FLAGS_net_api_test_port))).body);
+}
+
 TEST(HTTPAPI, PostFromInvalidFile) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   bricks::FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);

--- a/net/api/types.h
+++ b/net/api/types.h
@@ -70,11 +70,14 @@ struct GET : HTTPRequestBase<GET> {
 };
 
 struct POST : HTTPRequestBase<POST> {
+  bool has_body;
   std::string body;
   std::string content_type;
 
+  explicit POST(const std::string& url) : HTTPRequestBase(url), has_body(false) {}
+
   explicit POST(const std::string& url, const std::string& body, const std::string& content_type)
-      : HTTPRequestBase(url), body(body), content_type(content_type) {}
+      : HTTPRequestBase(url), has_body(true), body(body), content_type(content_type) {}
 };
 
 struct POSTFromFile : HTTPRequestBase<POSTFromFile> {

--- a/net/api/types.h
+++ b/net/api/types.h
@@ -36,6 +36,8 @@ SOFTWARE.
 #include "../exceptions.h"
 #include "../http/codes.h"
 
+#include "../../cerealize/cerealize.h"
+
 namespace bricks {
 namespace net {
 namespace api {
@@ -78,6 +80,16 @@ struct POST : HTTPRequestBase<POST> {
 
   explicit POST(const std::string& url, const std::string& body, const std::string& content_type)
       : HTTPRequestBase(url), has_body(true), body(body), content_type(content_type) {}
+
+  template <typename T>
+  explicit POST(const std::string& url, const T& object)
+      : HTTPRequestBase(url),
+        has_body(true),
+        body(cerealize::JSON(object, "data")),
+        content_type("application/json") {
+    static_assert(cerealize::is_write_cerealizable<T>::value,
+                  "This form of POST() requires a cerealizable object as the second parameter.");
+  }
 };
 
 struct POSTFromFile : HTTPRequestBase<POSTFromFile> {

--- a/net/http/codes.h
+++ b/net/http/codes.h
@@ -77,60 +77,57 @@ enum class HTTPResponseCode : int {
   HTTPVersionNotSupported = 505,
 };
 
-class HTTPResponseCodeAsStringGenerator {
- public:
-  static inline std::string CodeAsString(HTTPResponseCode code) {
-    static const std::map<int, std::string> codes = {
-        {100, "Continue"},
-        {101, "Switching Protocols"},
-        {200, "OK"},
-        {201, "Created"},
-        {202, "Accepted"},
-        {203, "Non-Authoritative Information"},
-        {204, "No Content"},
-        {205, "Reset Content"},
-        {206, "Partial Content"},
-        {300, "Multiple Choices"},
-        {301, "Moved Permanently"},
-        {302, "Found"},
-        {303, "See Other"},
-        {304, "Not Modified"},
-        {305, "Use Proxy"},
-        {307, "Temporary Redirect"},
-        {400, "Bad Request"},
-        {401, "Unauthorized"},
-        {402, "Payment Required"},
-        {403, "Forbidden"},
-        {404, "Not Found"},
-        {405, "Method Not Allowed"},
-        {406, "Not Acceptable"},
-        {407, "Proxy Authentication Required"},
-        {408, "Request Time-out"},
-        {409, "Conflict"},
-        {410, "Gone"},
-        {411, "Length Required"},
-        {412, "Precondition Failed"},
-        {413, "Request Entity Too Large"},
-        {414, "Request-URI Too Large"},
-        {415, "Unsupported Media Type"},
-        {416, "Requested range not satisfiable"},
-        {417, "Expectation Failed"},
-        {500, "Internal Server Error"},
-        {501, "Not Implemented"},
-        {502, "Bad Gateway"},
-        {503, "Service Unavailable"},
-        {504, "Gateway Time-out"},
-        {505, "HTTP Version not supported"},
-        {-1, "<UNINITIALIZED>"}  // `-1` is used internally by Bricks as `uninitialized`.
-    };
-    const auto cit = codes.find(static_cast<int>(code));
-    if (cit != codes.end()) {
-      return cit->second;
-    } else {
-      return "Unknown Code";
-    }
+inline std::string HTTPResponseCodeAsString(HTTPResponseCode code) {
+  static const std::map<int, std::string> codes = {
+      {100, "Continue"},
+      {101, "Switching Protocols"},
+      {200, "OK"},
+      {201, "Created"},
+      {202, "Accepted"},
+      {203, "Non-Authoritative Information"},
+      {204, "No Content"},
+      {205, "Reset Content"},
+      {206, "Partial Content"},
+      {300, "Multiple Choices"},
+      {301, "Moved Permanently"},
+      {302, "Found"},
+      {303, "See Other"},
+      {304, "Not Modified"},
+      {305, "Use Proxy"},
+      {307, "Temporary Redirect"},
+      {400, "Bad Request"},
+      {401, "Unauthorized"},
+      {402, "Payment Required"},
+      {403, "Forbidden"},
+      {404, "Not Found"},
+      {405, "Method Not Allowed"},
+      {406, "Not Acceptable"},
+      {407, "Proxy Authentication Required"},
+      {408, "Request Time-out"},
+      {409, "Conflict"},
+      {410, "Gone"},
+      {411, "Length Required"},
+      {412, "Precondition Failed"},
+      {413, "Request Entity Too Large"},
+      {414, "Request-URI Too Large"},
+      {415, "Unsupported Media Type"},
+      {416, "Requested range not satisfiable"},
+      {417, "Expectation Failed"},
+      {500, "Internal Server Error"},
+      {501, "Not Implemented"},
+      {502, "Bad Gateway"},
+      {503, "Service Unavailable"},
+      {504, "Gateway Time-out"},
+      {505, "HTTP Version not supported"},
+      {-1, "<UNINITIALIZED>"}  // `-1` is used internally by Bricks as `uninitialized`.
+  };
+  const auto cit = codes.find(static_cast<int>(code));
+  if (cit != codes.end()) {
+    return cit->second;
+  } else {
+    return "Unknown Code";
   }
-};
+}
 
 }  // namespace net
 }  // namespace bricks

--- a/net/http/impl/server.h
+++ b/net/http/impl/server.h
@@ -474,10 +474,9 @@ class HTTPServerConnection {
     std::unique_ptr<Impl> impl_;
   };
 
-  inline ChunkedResponseSender SendChunkedHTTPResponse(
-      HTTPResponseCode code = HTTPResponseCode::OK,
-      const std::string& content_type = DefaultContentType(),
-      const HTTPHeaders& extra_headers = HTTPHeaders()) {
+  inline ChunkedResponseSender SendChunkedHTTPResponse(HTTPResponseCode code = HTTPResponseCode::OK,
+                                                       const std::string& content_type = DefaultContentType(),
+                                                       const HTTPHeaders& extra_headers = HTTPHeaders()) {
     std::ostringstream os;
     PrepareHTTPResponseHeader(os, ConnectionKeepAlive, code, content_type, extra_headers);
     os << "Transfer-Encoding: chunked" << kCRLF << kCRLF;

--- a/net/http/impl/server.h
+++ b/net/http/impl/server.h
@@ -25,8 +25,6 @@ SOFTWARE.
 #ifndef BRICKS_NET_HTTP_IMPL_SERVER_H
 #define BRICKS_NET_HTTP_IMPL_SERVER_H
 
-#include <iostream>  // TODO(dkorolev): Remove it.
-
 #include <map>
 #include <sstream>
 #include <string>
@@ -34,6 +32,7 @@ SOFTWARE.
 #include <memory>
 
 #include "../codes.h"
+#include "../mime_type.h"
 
 #include "../../exceptions.h"
 
@@ -330,7 +329,7 @@ class HTTPServerConnection {
                                                const std::string& content_type = DefaultContentType(),
                                                const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
     os << "HTTP/1.1 " << static_cast<int>(code);
-    os << " " << HTTPResponseCodeAsStringGenerator::CodeAsString(code) << kCRLF;
+    os << " " << HTTPResponseCodeAsString(code) << kCRLF;
     os << "Content-Type: " << content_type << kCRLF;
     os << "Connection: " << (connection_type == ConnectionKeepAlive ? "keep-alive" : "close") << kCRLF;
     for (const auto cit : extra_headers) {

--- a/net/http/impl/server.h
+++ b/net/http/impl/server.h
@@ -45,7 +45,7 @@ SOFTWARE.
 namespace bricks {
 namespace net {
 
-typedef std::vector<std::pair<std::string, std::string>> HTTPHeadersType;
+typedef std::vector<std::pair<std::string, std::string>> HTTPHeaders;
 
 // HTTP constants to parse the header and extract method, URL, headers and body.
 namespace {
@@ -327,7 +327,7 @@ class HTTPServerConnection {
                                                ConnectionType connection_type,
                                                HTTPResponseCode code = HTTPResponseCode::OK,
                                                const std::string& content_type = DefaultContentType(),
-                                               const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+                                               const HTTPHeaders& extra_headers = HTTPHeaders()) {
     os << "HTTP/1.1 " << static_cast<int>(code);
     os << " " << HTTPResponseCodeAsString(code) << kCRLF;
     os << "Content-Type: " << content_type << kCRLF;
@@ -343,7 +343,7 @@ class HTTPServerConnection {
                                    const T& end,
                                    HTTPResponseCode code,
                                    const std::string& content_type,
-                                   const HTTPHeadersType& extra_headers) {
+                                   const HTTPHeaders& extra_headers) {
     std::ostringstream os;
     PrepareHTTPResponseHeader(os, ConnectionClose, code, content_type, extra_headers);
     os << "Content-Length: " << (end - begin) << kCRLF << kCRLF;
@@ -358,7 +358,7 @@ class HTTPServerConnection {
       const T& end,
       HTTPResponseCode code = HTTPResponseCode::OK,
       const std::string& content_type = DefaultContentType(),
-      const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+      const HTTPHeaders& extra_headers = HTTPHeaders()) {
     SendHTTPResponseImpl(begin, end, code, content_type, extra_headers);
   }
   template <typename T>
@@ -366,7 +366,7 @@ class HTTPServerConnection {
   SendHTTPResponse(T&& container,
                    HTTPResponseCode code = HTTPResponseCode::OK,
                    const std::string& content_type = DefaultContentType(),
-                   const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+                   const HTTPHeaders& extra_headers = HTTPHeaders()) {
     SendHTTPResponseImpl(container.begin(), container.end(), code, content_type, extra_headers);
   }
 
@@ -374,7 +374,7 @@ class HTTPServerConnection {
   inline void SendHTTPResponse(const std::string& string,
                                HTTPResponseCode code = HTTPResponseCode::OK,
                                const std::string& content_type = DefaultContentType(),
-                               const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+                               const HTTPHeaders& extra_headers = HTTPHeaders()) {
     SendHTTPResponseImpl(string.begin(), string.end(), code, content_type, extra_headers);
   }
   // Support objects that can be serialized as JSON-s via Cereal.
@@ -383,7 +383,7 @@ class HTTPServerConnection {
       T&& object,
       HTTPResponseCode code = HTTPResponseCode::OK,
       const std::string& content_type = DefaultContentType(),
-      const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+      const HTTPHeaders& extra_headers = HTTPHeaders()) {
     // TODO(dkorolev): We should probably make this not only correct but also efficient.
     const std::string s = cerealize::JSON(object) + '\n';
     SendHTTPResponseImpl(s.begin(), s.end(), code, content_type, extra_headers);
@@ -397,7 +397,7 @@ class HTTPServerConnection {
       S&& name,
       HTTPResponseCode code = HTTPResponseCode::OK,
       const std::string& content_type = DefaultContentType(),
-      const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+      const HTTPHeaders& extra_headers = HTTPHeaders()) {
     // TODO(dkorolev): We should probably make this not only correct but also efficient.
     const std::string s = cerealize::JSON(object, name) + '\n';
     SendHTTPResponseImpl(s.begin(), s.end(), code, content_type, extra_headers);
@@ -477,7 +477,7 @@ class HTTPServerConnection {
   inline ChunkedResponseSender SendChunkedHTTPResponse(
       HTTPResponseCode code = HTTPResponseCode::OK,
       const std::string& content_type = DefaultContentType(),
-      const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+      const HTTPHeaders& extra_headers = HTTPHeaders()) {
     std::ostringstream os;
     PrepareHTTPResponseHeader(os, ConnectionKeepAlive, code, content_type, extra_headers);
     os << "Transfer-Encoding: chunked" << kCRLF << kCRLF;

--- a/net/http/mime_type.h
+++ b/net/http/mime_type.h
@@ -28,6 +28,8 @@ SOFTWARE.
 #ifndef BRICKS_NET_HTTP_MIME_TYPE_H
 #define BRICKS_NET_HTTP_MIME_TYPE_H
 
+#include <algorithm>
+#include <cctype>
 #include <map>
 #include <string>
 
@@ -51,7 +53,9 @@ inline std::string GetFileMimeType(const std::string& file_name) {
       {"svg", "image/svg+xml"}  // TODO(sompylasar): Is this the right MIME for svg?
   };
 
-  const auto cit = file_extension_to_mime_type_map.find(bricks::FileSystem::GetFileExtension(file_name));
+  std::string extension = bricks::FileSystem::GetFileExtension(file_name);
+  std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+  const auto cit = file_extension_to_mime_type_map.find(extension);
   if (cit != file_extension_to_mime_type_map.end()) {
     return cit->second;
   } else {

--- a/net/http/mime_type.h
+++ b/net/http/mime_type.h
@@ -1,7 +1,8 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+Copyright (c) 2015 Ivan "John" Babak
+                   Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +23,43 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#ifndef BRICKS_NET_HTTP_HTTP_H
-#define BRICKS_NET_HTTP_HTTP_H
+// TODO(sompylasar): Your name and e-mail spelling in the header?
 
-#include "../../port.h"
+#ifndef BRICKS_NET_HTTP_MIME_TYPE_H
+#define BRICKS_NET_HTTP_MIME_TYPE_H
 
-#include "codes.h"
-#include "mime_type.h"
+#include <map>
+#include <string>
 
-#if defined(BRICKS_POSIX) || defined(BRICKS_APPLE) || defined(BRICKS_JAVA) || defined(BRICKS_WINDOWS)
-#include "impl/server.h"
-#else
-#error "No implementation for `net/http.h` is available for your system."
-#endif
+#include "../../file/file.h"
 
-#endif  // BRICKS_NET_HTTP_HTTP_H
+namespace bricks {
+namespace net {
+
+inline std::string GetFileMimeType(const std::string& file_name) {
+  static const std::map<std::string, std::string> file_extension_to_mime_type_map = {
+      {"js", "application/javascript"},
+      {"json", "application/json"},
+      {"css", "text/css"},
+      {"html", "text/html"},
+      {"htm", "text/html"},
+      {"txt", "text/plain"},
+      {"png", "image/png"},
+      {"jpg", "image/jpeg"},
+      {"jpeg", "image/jpeg"},
+      {"gif", "image/gif"},
+      {"svg", "image/svg+xml"}  // TODO(sompylasar): Is this the right MIME for svg?
+  };
+
+  const auto cit = file_extension_to_mime_type_map.find(bricks::FileSystem::GetFileExtension(file_name));
+  if (cit != file_extension_to_mime_type_map.end()) {
+    return cit->second;
+  } else {
+    return "text/plain";
+  }
+}
+
+}  // namespace net
+}  // namespace bricks
+
+#endif  // BRICKS_NET_HTTP_MIME_TYPE_H

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -545,4 +545,7 @@ TEST(HTTPMimeTypeTest, SmokeTest) {
   EXPECT_EQ("image/png", GetFileMimeType("file.png"));
   EXPECT_EQ("text/html", GetFileMimeType("dir.png/file.html"));
   EXPECT_EQ("text/plain", GetFileMimeType("dir.html/"));
+  EXPECT_EQ("text/plain", GetFileMimeType("file.FOO"));
+  EXPECT_EQ("text/html", GetFileMimeType("file.hTmL"));
+  EXPECT_EQ("image/png", GetFileMimeType("file.PNG"));
 }

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -49,7 +49,8 @@ using bricks::net::Connection;
 using bricks::net::HTTPServerConnection;
 using bricks::net::HTTPRequestData;
 using bricks::net::HTTPResponseCode;
-using bricks::net::HTTPResponseCodeAsStringGenerator;
+using bricks::net::HTTPResponseCodeAsString;
+using bricks::net::GetFileMimeType;
 using bricks::net::HTTPNoBodyProvidedException;
 using bricks::net::ConnectionResetByPeer;
 
@@ -531,20 +532,17 @@ TYPED_TEST(HTTPTest, NoBodyPOST) {
   EXPECT_EQ("ALMOST_POSTED", TypeParam::Fetch(t, "/unittest_empty_post", "POST"));
 }
 
-TEST(HTTPCodesTest, Code200) {
-  EXPECT_EQ("OK", HTTPResponseCodeAsStringGenerator::CodeAsString(static_cast<HTTPResponseCode>(200)));
+TEST(HTTPCodesTest, SmokeTest) {
+  EXPECT_EQ("OK", HTTPResponseCodeAsString(static_cast<HTTPResponseCode>(200)));
+  EXPECT_EQ("Not Found", HTTPResponseCodeAsString(static_cast<HTTPResponseCode>(404)));
+  EXPECT_EQ("Unknown Code", HTTPResponseCodeAsString(static_cast<HTTPResponseCode>(999)));
+  EXPECT_EQ("<UNINITIALIZED>", HTTPResponseCodeAsString(static_cast<HTTPResponseCode>(-1)));
 }
 
-TEST(HTTPCodesTest, Code404) {
-  EXPECT_EQ("Not Found", HTTPResponseCodeAsStringGenerator::CodeAsString(static_cast<HTTPResponseCode>(404)));
-}
-
-TEST(HTTPCodesTest, CodeUnknown) {
-  EXPECT_EQ("Unknown Code",
-            HTTPResponseCodeAsStringGenerator::CodeAsString(static_cast<HTTPResponseCode>(999)));
-}
-
-TEST(HTTPCodesTest, CodeInternalUninitialized) {
-  EXPECT_EQ("<UNINITIALIZED>",
-            HTTPResponseCodeAsStringGenerator::CodeAsString(static_cast<HTTPResponseCode>(-1)));
+TEST(HTTPMimeTypeTest, SmokeTest) {
+  EXPECT_EQ("text/plain", GetFileMimeType("file.foo"));
+  EXPECT_EQ("text/html", GetFileMimeType("file.html"));
+  EXPECT_EQ("image/png", GetFileMimeType("file.png"));
+  EXPECT_EQ("text/html", GetFileMimeType("dir.png/file.html"));
+  EXPECT_EQ("text/plain", GetFileMimeType("dir.html/"));
 }

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -85,6 +85,7 @@ TEST(PosixHTTPServerTest, Smoke) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
       "Content-Length: 10\r\n"
       "\r\n"
       "Data: BODY",
@@ -110,6 +111,7 @@ TEST(PosixHTTPServerTest, SmokeWithArray) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
       "Content-Length: 5\r\n"
       "\r\n"
       "Aloha",
@@ -135,6 +137,7 @@ TEST(PosixHTTPServerTest, SmokeWithObject) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
       "Content-Length: 55\r\n"
       "\r\n"
       "{\"value0\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n",
@@ -158,6 +161,7 @@ TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
       "Content-Length: 60\r\n"
       "\r\n"
       "{\"epic_object\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n",
@@ -185,6 +189,7 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
+      "Connection: keep-alive\r\n"
       "Transfer-Encoding: chunked\r\n"
       "\r\n"
       "B\r\n"
@@ -220,6 +225,7 @@ TEST(PosixHTTPServerTest, SmokeWithHeaders) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: custom_content_type\r\n"
+      "Connection: close\r\n"
       "foo: bar\r\n"
       "baz: meh\r\n"
       "Content-Length: 2\r\n"
@@ -247,6 +253,7 @@ TEST(PosixHTTPServerTest, NoEOF) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
       "Content-Length: 11\r\n"
       "\r\n"
       "Data: NOEOF",
@@ -276,6 +283,7 @@ TEST(PosixHTTPServerTest, LargeBody) {
   EXPECT_EQ(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
       "Content-Length: 1000006\r\n"
       "\r\n"
       "Data: " +
@@ -312,6 +320,7 @@ TEST(PosixHTTPServerTest, ChunkedLargeBodyManyChunks) {
   EXPECT_EQ(strings::Printf(
                 "HTTP/1.1 200 OK\r\n"
                 "Content-Type: text/plain\r\n"
+                "Connection: close\r\n"
                 "Content-Length: %d\r\n"
                 "\r\n"
                 "%s",
@@ -349,6 +358,7 @@ TEST(PosixHTTPServerTest, ChunkedBodyLargeFirstChunk) {
   EXPECT_EQ(strings::Printf(
                 "HTTP/1.1 200 OK\r\n"
                 "Content-Type: text/plain\r\n"
+                "Connection: close\r\n"
                 "Content-Length: %d\r\n"
                 "\r\n"
                 "%s",


### PR DESCRIPTION
* HTTP(POST(...)) can now be run without body.
* HTTP(POST(...)) can now accept user object directly, it will be JSON-ified automatically.
* Added a somewhat smart ```JSONParse<>```.
* Ported @sompylasar's MIME type detection code into Bricks.
* Added ```Connection: close/keep-alive``` as part of Bricks' ```net/api```.
* A few minor cleanup changes. 