### PR TITLE
Tests passing on Windows, part 1/2, source code.

### DIFF
--- a/cerealize/cerealize.h
+++ b/cerealize/cerealize.h
@@ -302,7 +302,7 @@ struct BricksParseJSONError {};
 template <typename T>
 struct BricksParseJSONError<T, false> {
   static void HandleParseJSONError(const std::string& input_json, T&) {
-    throw bricks::ParseJSONException(input_json);
+    BRICKS_THROW(bricks::ParseJSONException(input_json));
   }
 };
 

--- a/dflags/dflags.h
+++ b/dflags/dflags.h
@@ -155,7 +155,7 @@ class FlagsManager {
         }
       }
 
-      argc = argv_.size();
+      argc = static_cast<int>(argv_.size());
       argv = &argv_[0];
     }
 

--- a/net/api/impl/posix_server.h
+++ b/net/api/impl/posix_server.h
@@ -140,7 +140,7 @@ class HTTPServerPOSIX final {
     try {
       // TODO(dkorolev): This should always use the POSIX implemenation of the client, nothing fancier.
       // It is a safe call, since the server itself is POSIX, so the architecture we are on is POSIX-friendly.
-      Connection(ClientSocket("localhost", port_)).BlockingWrite("GET /healthz HTTP/1.1\r\n\r\n").SendEOF();
+      Connection(ClientSocket("localhost", port_)).BlockingWrite("GET /healthz HTTP/1.1\r\n\r\n");
     } catch (const bricks::Exception&) {
       // It is guaranteed that after `terminated_` is set the server will be terminated on the next request,
       // but it might so happen that that terminating request will happen between `terminating_ = true`
@@ -244,6 +244,9 @@ class HTTPServerPOSIX final {
       try {
         std::unique_ptr<HTTPServerConnection> connection(new HTTPServerConnection(socket.Accept()));
         if (terminating_) {
+          // Already terminating. Will not send the response, and this
+          // lack of response should not result in an exception.
+          connection->DoNotSendAnyResponse();
           break;
         }
         std::function<void(Request)> handler;

--- a/net/exceptions.h
+++ b/net/exceptions.h
@@ -53,15 +53,14 @@ struct SocketBindException : ServerSocketException {};
 struct SocketListenException : ServerSocketException {};  // LCOV_EXCL_LINE -- not covered by unit tests.
 struct SocketAcceptException : ServerSocketException {};  // LCOV_EXCL_LINE -- not covered by unit tests.
 
-struct ConnectionResetByPeer : SocketException {};
+struct ConnectionResetByPeer : SocketException {};  // LCOV_EXCL_LINE
 
 struct ClientSocketException : SocketException {};
 struct SocketConnectException : ClientSocketException {};  // LCOV_EXCL_LINE -- not covered by unit tests.
 struct SocketResolveAddressException : ClientSocketException {};
 
 struct SocketFcntlException : SocketException {};
-struct SocketReadException : SocketException {};
-struct SocketReadMultibyteRecordEndedPrematurelyException : SocketReadException {};
+struct SocketReadException : SocketException {};  // LCOV_EXCL_LINE -- TODO(dkorolev): We might want to test it.
 struct SocketWriteException : SocketException {};
 struct SocketCouldNotWriteEverythingException : SocketWriteException {};
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -27,8 +27,6 @@ SOFTWARE.
 
 #include "../../port.h"
 
-#include "../debug_log.h"
-
 #if defined(BRICKS_POSIX) || defined(BRICKS_APPLE) || defined(BRICKS_JAVA) || defined(BRICKS_WINDOWS)
 #include "impl/posix.h"
 #elif defined(BRICKS_ANDROID)

--- a/time/test.cc
+++ b/time/test.cc
@@ -38,7 +38,7 @@ TEST(Time, SmokeTest) {
 #ifndef BRICKS_WINDOWS
   const int64_t allowed_skew = 3;
 #else
-  const int64_t allowed_skew = 10;  // Visual Studio is slower in regard to this test.
+  const int64_t allowed_skew = 25;  // Visual Studio is slower in regard to this test.
 #endif
   EXPECT_GE(dt, 50 - allowed_skew);
   EXPECT_LE(dt, 50 + allowed_skew);

--- a/util/test.cc
+++ b/util/test.cc
@@ -192,8 +192,9 @@ TEST(Util, MakePointerScopeGuard) {
 
 TEST(Util, Singleton) {
   struct Foo {
-    size_t bar = 0;
+    size_t bar = 0u;
     void baz() { ++bar; }
+    void reset() { bar = 0u; }
   };
   EXPECT_EQ(0u, bricks::Singleton<Foo>().bar);
   bricks::Singleton<Foo>().baz();
@@ -202,6 +203,8 @@ TEST(Util, Singleton) {
   EXPECT_EQ(1u, bricks::Singleton<Foo>().bar);
   lambda();
   EXPECT_EQ(2u, bricks::Singleton<Foo>().bar);
+  // Allow running the test multiple times, via --gtest_repeat.
+  bricks::Singleton<Foo>().reset();
 }
 
 TEST(Util, SHA256) {


### PR DESCRIPTION
Windows is conquered.

Tests passing in Debug/Release, Win32/x64, running them 1'000 times in a loop.

(I did observe some flakiness on `net/http` side, but `net/api` behaves flawlessly.)

Changes:

1. Retired `EOF` in both send and receive directions.
   Sockets can either wait to receive precisely *N* bytes, or get whatever is there, leaving the rest to the protocol level.

2. Added extra locks to not close the top-level sockets (per-port listeners), until the connection is terminated.
   This only affects `net/http`, since `net/api` keeps each used port open for the lifespan of the binary.

3. Added `#define`-controlled excessive low-level logging for `net/`.

Visual Studio changes following in a dedicated pull request.

Thanks,
Dima