### PR TITLE
Fixed 'indent' in net/Makefile.

### DIFF
--- a/net/Makefile
+++ b/net/Makefile
@@ -4,7 +4,7 @@ default:
 	(cd url; make default) && (cd tcp; make default) && (cd http; make default) && (cd api; make default) && echo "ALL TESTS PASS"
 
 indent:
-	(find . -name "*.cc" ; find . -name "*.h") | xargs clang-format-3.5 -i
+	../KnowSheet/scripts/indent.sh
 
 clean:
 	rm -rf build .noshit


### PR DESCRIPTION
`make indent` from `net/` was indenting the `docu_` files as well, ruining `README.md`. Fixed now.

@deathbaba : Please post-review.