### PR TITLE
Finalizing net/{api+tcp} and locking down net/http. Several simplifications.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ everything
 zzz_full_test/everything
 coverage
 zzz_full_test/coverage
+zzz_full_test/coverage0.info  # A temporary file, appears for a while during `make`, ignore to be safe.
 
 # Microsoft Visual Studio files.
 *.suo

--- a/3party/gtest/gtest-main-with-dflags.h
+++ b/3party/gtest/gtest-main-with-dflags.h
@@ -20,6 +20,9 @@ int main(int argc, char** argv) {
   // Postpone the `Death tests use fork(), which is unsafe particularly in a threaded context.` warning.
   // Via https://code.google.com/p/googletest/wiki/AdvancedGuide#Death_Test_Styles
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  // Very useful when using `--gtest_repeat=N`.
+  // I have no clue why doesn't it default to true -- D.K.
+  ::testing::FLAGS_gtest_break_on_failure = true;
   const auto result = RUN_ALL_TESTS();
 #ifdef _WIN32
   // It's easier for the developers to just press Enter after the tests are done compared to

--- a/3party/gtest/gtest-main.h
+++ b/3party/gtest/gtest-main.h
@@ -15,6 +15,9 @@ int main(int argc, char** argv) {
   // Postpone the `Death tests use fork(), which is unsafe particularly in a threaded context.` warning.
   // Via https://code.google.com/p/googletest/wiki/AdvancedGuide#Death_Test_Styles
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  // Very useful when using `--gtest_repeat=N`.
+  // I have no clue why doesn't it default to true -- D.K.
+  ::testing::FLAGS_gtest_break_on_failure = true;
   const auto result = RUN_ALL_TESTS();
 #ifdef _WIN32
   // It's easier for the developers to just press Enter after the tests are done compared to

--- a/net/api/impl/posix_client.h
+++ b/net/api/impl/posix_client.h
@@ -70,21 +70,22 @@ class HTTPClientPOSIX final {
       }
       all_urls.insert(composed_url);
       Connection connection(Connection(ClientSocket(parsed_url.host, parsed_url.port)));
-      connection.BlockingWrite(request_method_ + ' ' + parsed_url.path + parsed_url.ComposeParameters() +
-                               " HTTP/1.1\r\n");
-      connection.BlockingWrite("Host: " + parsed_url.host + "\r\n");
+      connection.BlockingWrite(
+          request_method_ + ' ' + parsed_url.path + parsed_url.ComposeParameters() + " HTTP/1.1\r\n", true);
+      connection.BlockingWrite("Host: " + parsed_url.host + "\r\n", true);
       if (!request_user_agent_.empty()) {
-        connection.BlockingWrite("User-Agent: " + request_user_agent_ + "\r\n");
+        connection.BlockingWrite("User-Agent: " + request_user_agent_ + "\r\n", true);
       }
       if (!request_body_content_type_.empty()) {
-        connection.BlockingWrite("Content-Type: " + request_body_content_type_ + "\r\n");
+        connection.BlockingWrite("Content-Type: " + request_body_content_type_ + "\r\n", true);
       }
       if (request_has_body_) {
-        connection.BlockingWrite("Content-Length: " + std::to_string(request_body_contents_.length()) + "\r\n");
-        connection.BlockingWrite("\r\n");
-        connection.BlockingWrite(request_body_contents_);
+        connection.BlockingWrite("Content-Length: " + std::to_string(request_body_contents_.length()) + "\r\n",
+                                 true);
+        connection.BlockingWrite("\r\n", true);
+        connection.BlockingWrite(request_body_contents_, false);
       } else {
-        connection.BlockingWrite("\r\n");
+        connection.BlockingWrite("\r\n", false);
       }
       // Attention! Achtung! Увага! Внимание!
       // Calling SendEOF() (which is ::shutdown(socket, SHUT_WR);) results in slowly sent data

--- a/net/api/impl/posix_client.h
+++ b/net/api/impl/posix_client.h
@@ -87,11 +87,6 @@ class HTTPClientPOSIX final {
       } else {
         connection.BlockingWrite("\r\n", false);
       }
-      // Attention! Achtung! Увага! Внимание!
-      // Calling SendEOF() (which is ::shutdown(socket, SHUT_WR);) results in slowly sent data
-      // not being received. Tested on local and remote data with "chunked" transfer encoding.
-      // Don't uncomment the next line!
-      // connection.SendEOF();
       http_request_.reset(new HTTPRedirectableRequestData(connection));
       // TODO(dkorolev): Rename `Path()`, it's only called so now because of HTTP request/response format.
       // Elaboration:

--- a/net/api/impl/posix_server.h
+++ b/net/api/impl/posix_server.h
@@ -140,7 +140,7 @@ class HTTPServerPOSIX final {
     try {
       // TODO(dkorolev): This should always use the POSIX implemenation of the client, nothing fancier.
       // It is a safe call, since the server itself is POSIX, so the architecture we are on is POSIX-friendly.
-      Connection(ClientSocket("localhost", port_)).BlockingWrite("GET /healthz HTTP/1.1\r\n\r\n");
+      Connection(ClientSocket("localhost", port_)).BlockingWrite("GET /healthz HTTP/1.1\r\n\r\n", true);
     } catch (const bricks::Exception&) {
       // It is guaranteed that after `terminated_` is set the server will be terminated on the next request,
       // but it might so happen that that terminating request will happen between `terminating_ = true`

--- a/net/api/test.cc
+++ b/net/api/test.cc
@@ -278,8 +278,7 @@ TEST(HTTPAPI, GetToFile) {
         if (!reduce) {
           reduce = true;
           return 10;
-        }
-        else {
+        } else {
           return 1;
         }
       }();

--- a/net/debug_log.h
+++ b/net/debug_log.h
@@ -39,7 +39,7 @@ SOFTWARE.
 #include <iostream>
 #include <thread>
 #include <mutex>
-#include "../../util/singleton.h"
+#include "../util/singleton.h"
 struct DebugLogMutex {
   std::mutex mutex;
 };

--- a/net/http/impl/server.h
+++ b/net/http/impl/server.h
@@ -195,11 +195,11 @@ class TemplatedHTTPRequestData : public HELPER {
                 const size_t bytes_to_read = next_offset - offset;
                 // The `+1` is required for the '\0'.
                 if (buffer_.size() < next_offset + 1) {
-                  // LCOV_EXCL_BEGIN
+                  // LCOV_EXCL_START
                   // TODO(dkorolev): See if this can be tested better; now the test for these lines is flaky.
                   buffer_.resize(
                       std::max(static_cast<size_t>(buffer_.size() * buffer_growth_k), next_offset + 1));
-                  // LCOV_EXCL_END
+                  // LCOV_EXCL_STOP
                 }
                 if (bytes_to_read !=
                     c.BlockingRead(&buffer_[offset], bytes_to_read, Connection::FillFullBuffer)) {

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -403,12 +403,10 @@ class HTTPClientImplPOSIX {
     connection.BlockingWrite(method + ' ' + url + "\r\n", true);
     if (has_data) {
       connection.BlockingWrite("Content-Length: " + to_string(data.length()) + "\r\n", true);
-    }
-    if (!has_data) {
-      connection.BlockingWrite("\r\n", false);
-    } else {
       connection.BlockingWrite("\r\n", true);
       connection.BlockingWrite(data, false);
+    else {
+      connection.BlockingWrite("\r\n", false);
     }
     HTTPRequestData http_request(connection);
     assert(http_request.HasBody());

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -63,8 +63,7 @@ static void ExpectToReceive(const std::string& golden, Connection& connection) {
     ASSERT_EQ(golden.length(),
               connection.BlockingRead(&response[0], golden.length(), Connection::FillFullBuffer));
     EXPECT_EQ(golden, std::string(response.begin(), response.end()));
-  }
-  catch (const SocketException& e) {
+  } catch (const SocketException& e) {
     ASSERT_TRUE(false) << e.What();
   }
 }
@@ -82,10 +81,10 @@ struct HTTPTestObject {
 
 TEST(PosixHTTPServerTest, Smoke) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("POST", c.HTTPRequest().Method());
-               EXPECT_EQ("/", c.HTTPRequest().RawPath());
-               c.SendHTTPResponse("Data: " + c.HTTPRequest().Body());
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("POST", c.HTTPRequest().Method());
+             EXPECT_EQ("/", c.HTTPRequest().RawPath());
+             c.SendHTTPResponse("Data: " + c.HTTPRequest().Body());
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -108,10 +107,10 @@ TEST(PosixHTTPServerTest, Smoke) {
 
 TEST(PosixHTTPServerTest, SmokeWithArray) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("GET", c.HTTPRequest().Method());
-               EXPECT_EQ("/aloha", c.HTTPRequest().RawPath());
-               c.SendHTTPResponse(std::vector<char>({'A', 'l', 'o', 'h', 'a'}));
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("GET", c.HTTPRequest().Method());
+             EXPECT_EQ("/aloha", c.HTTPRequest().RawPath());
+             c.SendHTTPResponse(std::vector<char>({'A', 'l', 'o', 'h', 'a'}));
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -132,10 +131,10 @@ TEST(PosixHTTPServerTest, SmokeWithArray) {
 
 TEST(PosixHTTPServerTest, SmokeWithObject) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("GET", c.HTTPRequest().Method());
-               EXPECT_EQ("/mahalo", c.HTTPRequest().RawPath());
-               c.SendHTTPResponse(HTTPTestObject());
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("GET", c.HTTPRequest().Method());
+             EXPECT_EQ("/mahalo", c.HTTPRequest().RawPath());
+             c.SendHTTPResponse(HTTPTestObject());
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -156,10 +155,10 @@ TEST(PosixHTTPServerTest, SmokeWithObject) {
 
 TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("GET", c.HTTPRequest().Method());
-               EXPECT_EQ("/mahalo", c.HTTPRequest().RawPath());
-               c.SendHTTPResponse(HTTPTestObject(), "epic_object");
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("GET", c.HTTPRequest().Method());
+             EXPECT_EQ("/mahalo", c.HTTPRequest().RawPath());
+             c.SendHTTPResponse(HTTPTestObject(), "epic_object");
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -179,14 +178,14 @@ TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
 
 TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("GET", c.HTTPRequest().Method());
-               EXPECT_EQ("/chunked", c.HTTPRequest().RawPath());
-               auto r = c.SendChunkedHTTPResponse();
-               r.Send("onetwothree");
-               r.Send(std::vector<char>({'f', 'o', 'o'}));
-               r.Send(HTTPTestObject());
-               r.Send(HTTPTestObject(), "epic_chunk");
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("GET", c.HTTPRequest().Method());
+             EXPECT_EQ("/chunked", c.HTTPRequest().RawPath());
+             auto r = c.SendChunkedHTTPResponse();
+             r.Send("onetwothree");
+             r.Send(std::vector<char>({'f', 'o', 'o'}));
+             r.Send(HTTPTestObject());
+             r.Send(HTTPTestObject(), "epic_chunk");
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -213,13 +212,14 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
 }
 
 TEST(PosixHTTPServerTest, SmokeWithHeaders) {
-  thread t([](Socket s) {
+  thread t(
+      [](Socket s) {
         HTTPServerConnection c(s.Accept());
         EXPECT_EQ("GET", c.HTTPRequest().Method());
         EXPECT_EQ("/header", c.HTTPRequest().RawPath());
         c.SendHTTPResponse("OK", HTTPResponseCode.OK, c.HTTPRequest().Body(), {{"foo", "bar"}, {"baz", "meh"}});
-    },
-    Socket(FLAGS_net_http_test_port));
+      },
+      Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
   connection.BlockingWrite("GET /header HTTP/1.1\r\n", true);
   connection.BlockingWrite("Host: localhost\r\n", true);
@@ -242,10 +242,10 @@ TEST(PosixHTTPServerTest, SmokeWithHeaders) {
 
 TEST(PosixHTTPServerTest, LargeBody) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("POST", c.HTTPRequest().Method());
-               EXPECT_EQ("/", c.HTTPRequest().RawPath());
-               c.SendHTTPResponse(std::string("Data: ") + c.HTTPRequest().Body());
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("POST", c.HTTPRequest().Method());
+             EXPECT_EQ("/", c.HTTPRequest().RawPath());
+             c.SendHTTPResponse(std::string("Data: ") + c.HTTPRequest().Body());
            },
            Socket(FLAGS_net_http_test_port));
   string body(1000000, '.');
@@ -272,10 +272,10 @@ TEST(PosixHTTPServerTest, LargeBody) {
 
 TEST(PosixHTTPServerTest, ChunkedLargeBodyManyChunks) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("POST", c.HTTPRequest().Method());
-               EXPECT_EQ("/", c.HTTPRequest().RawPath());
-               c.SendHTTPResponse(c.HTTPRequest().Body());
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("POST", c.HTTPRequest().Method());
+             EXPECT_EQ("/", c.HTTPRequest().RawPath());
+             c.SendHTTPResponse(c.HTTPRequest().Body());
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -311,10 +311,10 @@ TEST(PosixHTTPServerTest, ChunkedLargeBodyManyChunks) {
 // A dedicated test to cover buffer resize after the size of the next chunk has been received.
 TEST(PosixHTTPServerTest, ChunkedBodyLargeFirstChunk) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("POST", c.HTTPRequest().Method());
-               EXPECT_EQ("/", c.HTTPRequest().RawPath());
-               c.SendHTTPResponse(c.HTTPRequest().Body());
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("POST", c.HTTPRequest().Method());
+             EXPECT_EQ("/", c.HTTPRequest().RawPath());
+             c.SendHTTPResponse(c.HTTPRequest().Body());
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -358,9 +358,7 @@ struct HTTPClientImplCURL {
     return s;
   }
 
-  static string Fetch(thread& server_thread,
-                      const string& url,
-                      const string& method) {
+  static string Fetch(thread& server_thread, const string& url, const string& method) {
     const string result = Syscall(
         strings::Printf("curl -s -X %s localhost:%d%s", method.c_str(), FLAGS_net_http_test_port, url.c_str()));
     server_thread.join();
@@ -384,9 +382,7 @@ struct HTTPClientImplCURL {
 
 class HTTPClientImplPOSIX {
  public:
-  static string Fetch(thread& server_thread,
-                      const string& url,
-                      const string& method) {
+  static string Fetch(thread& server_thread, const string& url, const string& method) {
     return Impl(server_thread, url, method);
   }
 
@@ -434,12 +430,12 @@ TYPED_TEST_CASE(HTTPTest, HTTPClientImplsTypeList);
 
 TYPED_TEST(HTTPTest, GET) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("GET", c.HTTPRequest().Method());
-               EXPECT_EQ("/unittest?foo=bar", c.HTTPRequest().RawPath());
-               EXPECT_EQ("/unittest", c.HTTPRequest().URL().path);
-               EXPECT_EQ("bar", c.HTTPRequest().URL().query["foo"]);
-               c.SendHTTPResponse("PASSED");
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("GET", c.HTTPRequest().Method());
+             EXPECT_EQ("/unittest?foo=bar", c.HTTPRequest().RawPath());
+             EXPECT_EQ("/unittest", c.HTTPRequest().URL().path);
+             EXPECT_EQ("bar", c.HTTPRequest().URL().query["foo"]);
+             c.SendHTTPResponse("PASSED");
            },
            Socket(FLAGS_net_http_test_port));
   EXPECT_EQ("PASSED", TypeParam::Fetch(t, "/unittest?foo=bar", "GET"));
@@ -447,12 +443,12 @@ TYPED_TEST(HTTPTest, GET) {
 
 TYPED_TEST(HTTPTest, POST) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("POST", c.HTTPRequest().Method());
-               EXPECT_EQ("/unittest_post", c.HTTPRequest().RawPath());
-               ASSERT_TRUE(c.HTTPRequest().HasBody()) << "WTF!";
-               EXPECT_EQ("BAZINGA", c.HTTPRequest().Body());
-               c.SendHTTPResponse("POSTED");
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("POST", c.HTTPRequest().Method());
+             EXPECT_EQ("/unittest_post", c.HTTPRequest().RawPath());
+             ASSERT_TRUE(c.HTTPRequest().HasBody()) << "WTF!";
+             EXPECT_EQ("BAZINGA", c.HTTPRequest().Body());
+             c.SendHTTPResponse("POSTED");
            },
            Socket(FLAGS_net_http_test_port));
   EXPECT_EQ("POSTED", TypeParam::FetchWithBody(t, "/unittest_post", "POST", "BAZINGA"));
@@ -460,12 +456,12 @@ TYPED_TEST(HTTPTest, POST) {
 
 TYPED_TEST(HTTPTest, NoBodyPOST) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               EXPECT_EQ("POST", c.HTTPRequest().Method());
-               EXPECT_EQ("/unittest_empty_post", c.HTTPRequest().RawPath());
-               EXPECT_FALSE(c.HTTPRequest().HasBody());
-               ASSERT_THROW(c.HTTPRequest().Body(), HTTPNoBodyProvidedException);
-               c.SendHTTPResponse("ALMOST_POSTED");
+             HTTPServerConnection c(s.Accept());
+             EXPECT_EQ("POST", c.HTTPRequest().Method());
+             EXPECT_EQ("/unittest_empty_post", c.HTTPRequest().RawPath());
+             EXPECT_FALSE(c.HTTPRequest().HasBody());
+             ASSERT_THROW(c.HTTPRequest().Body(), HTTPNoBodyProvidedException);
+             c.SendHTTPResponse("ALMOST_POSTED");
            },
            Socket(FLAGS_net_http_test_port));
   EXPECT_EQ("ALMOST_POSTED", TypeParam::Fetch(t, "/unittest_empty_post", "POST"));
@@ -473,10 +469,10 @@ TYPED_TEST(HTTPTest, NoBodyPOST) {
 
 TYPED_TEST(HTTPTest, AttemptsToSendResponseTwice) {
   thread t([](Socket s) {
-               HTTPServerConnection c(s.Accept());
-               c.SendHTTPResponse("one");
-               ASSERT_THROW(c.SendHTTPResponse("two"), AttemptedToSendHTTPResponseMoreThanOnce);
-               ASSERT_THROW(c.SendChunkedHTTPResponse().Send("three"), AttemptedToSendHTTPResponseMoreThanOnce);
+             HTTPServerConnection c(s.Accept());
+             c.SendHTTPResponse("one");
+             ASSERT_THROW(c.SendHTTPResponse("two"), AttemptedToSendHTTPResponseMoreThanOnce);
+             ASSERT_THROW(c.SendChunkedHTTPResponse().Send("three"), AttemptedToSendHTTPResponseMoreThanOnce);
            },
            Socket(FLAGS_net_http_test_port));
   EXPECT_EQ("one", TypeParam::Fetch(t, "/", "GET"));
@@ -484,8 +480,7 @@ TYPED_TEST(HTTPTest, AttemptsToSendResponseTwice) {
 
 TYPED_TEST(HTTPTest, DoesNotSendResponseAtAll) {
   EXPECT_EQ("<h1>INTERNAL SERVER ERROR</h1>\n", DefaultInternalServerErrorMessage());
-  thread t([](Socket s) { HTTPServerConnection c(s.Accept()); },
-           Socket(FLAGS_net_http_test_port));
+  thread t([](Socket s) { HTTPServerConnection c(s.Accept()); }, Socket(FLAGS_net_http_test_port));
   EXPECT_EQ(DefaultInternalServerErrorMessage(), TypeParam::Fetch(t, "/", "GET"));
 }
 

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -63,8 +63,8 @@ static void ExpectToReceive(const std::string& golden, Connection& connection) {
     ASSERT_EQ(golden.length(),
               connection.BlockingRead(&response[0], golden.length(), Connection::FillFullBuffer));
     EXPECT_EQ(golden, std::string(response.begin(), response.end()));
-  } catch (const SocketException& e) {
-    ASSERT_TRUE(false) << e.What();
+  } catch (const SocketException& e) {  // LCOV_EXCL_LINE
+    ASSERT_TRUE(false) << e.What();     // LCOV_EXCL_LINE
   }
 }
 

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -23,7 +23,6 @@ SOFTWARE.
 *******************************************************************************/
 
 #include <thread>
-#include <atomic>
 
 #include "../../port.h"
 
@@ -76,24 +75,11 @@ struct HTTPTestObject {
 };
 
 TEST(PosixHTTPServerTest, Smoke) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("POST", c.HTTPRequest().Method());
                EXPECT_EQ("/", c.HTTPRequest().RawPath());
                c.SendHTTPResponse("Data: " + c.HTTPRequest().Body());
-             }
-
-             // The `test_done` magic is required since the top-level HTTP-listening socket that accepts
-             // connections
-             // should not be closed until all the clients have finished reading their data.
-             // This issue does not appear in `net/api` since the serving threads per port run forever,
-             // however, extra logic is required to have this `net/http` test pass safely.
-             // TODO(dkorolev): Use `WaitableAtomic` here.
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -111,22 +97,15 @@ TEST(PosixHTTPServerTest, Smoke) {
       "\r\n"
       "Data: BODY",
       connection);
-  test_done = true;
   t.join();
 }
 
 TEST(PosixHTTPServerTest, SmokeWithArray) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("GET", c.HTTPRequest().Method());
                EXPECT_EQ("/aloha", c.HTTPRequest().RawPath());
                c.SendHTTPResponse(std::vector<char>({'A', 'l', 'o', 'h', 'a'}));
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -142,22 +121,15 @@ TEST(PosixHTTPServerTest, SmokeWithArray) {
       "\r\n"
       "Aloha",
       connection);
-  test_done = true;
   t.join();
 }
 
 TEST(PosixHTTPServerTest, SmokeWithObject) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("GET", c.HTTPRequest().Method());
                EXPECT_EQ("/mahalo", c.HTTPRequest().RawPath());
                c.SendHTTPResponse(HTTPTestObject());
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -173,22 +145,15 @@ TEST(PosixHTTPServerTest, SmokeWithObject) {
       "\r\n"
       "{\"value0\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n",
       connection);
-  test_done = true;
   t.join();
 }
 
 TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("GET", c.HTTPRequest().Method());
                EXPECT_EQ("/mahalo", c.HTTPRequest().RawPath());
                c.SendHTTPResponse(HTTPTestObject(), "epic_object");
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -203,14 +168,11 @@ TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
       "\r\n"
       "{\"epic_object\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n",
       connection);
-  test_done = true;
   t.join();
 }
 
 TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("GET", c.HTTPRequest().Method());
                EXPECT_EQ("/chunked", c.HTTPRequest().RawPath());
@@ -219,10 +181,6 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
                r.Send(std::vector<char>({'f', 'o', 'o'}));
                r.Send(HTTPTestObject());
                r.Send(HTTPTestObject(), "epic_chunk");
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -245,23 +203,15 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
       "{\"epic_chunk\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n\r\n"
       "0\r\n",
       connection);
-  test_done = true;
   t.join();
 }
 
 TEST(PosixHTTPServerTest, SmokeWithHeaders) {
-  std::atomic_bool test_done(false);
-  thread
-  t([&test_done](Socket s) {
-      {
+  thread t([](Socket s) {
         HTTPServerConnection c(s.Accept());
         EXPECT_EQ("GET", c.HTTPRequest().Method());
         EXPECT_EQ("/header", c.HTTPRequest().RawPath());
         c.SendHTTPResponse("OK", HTTPResponseCode.OK, c.HTTPRequest().Body(), {{"foo", "bar"}, {"baz", "meh"}});
-      }
-      while (!test_done) {
-        ;  // Spin lock.
-      }
     },
     Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -281,22 +231,15 @@ TEST(PosixHTTPServerTest, SmokeWithHeaders) {
       "\r\n"
       "OK",
       connection);
-  test_done = true;
   t.join();
 }
 
 TEST(PosixHTTPServerTest, LargeBody) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("POST", c.HTTPRequest().Method());
                EXPECT_EQ("/", c.HTTPRequest().RawPath());
                c.SendHTTPResponse(std::string("Data: ") + c.HTTPRequest().Body());
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   string body(1000000, '.');
@@ -318,22 +261,15 @@ TEST(PosixHTTPServerTest, LargeBody) {
       "Data: " +
           body,
       connection);
-  test_done = true;
   t.join();
 }
 
 TEST(PosixHTTPServerTest, ChunkedLargeBodyManyChunks) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("POST", c.HTTPRequest().Method());
                EXPECT_EQ("/", c.HTTPRequest().RawPath());
                c.SendHTTPResponse(c.HTTPRequest().Body());
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -363,23 +299,16 @@ TEST(PosixHTTPServerTest, ChunkedLargeBodyManyChunks) {
                       static_cast<int>(body.length()),
                       body.c_str()),
                   connection);
-  test_done = true;
   t.join();
 }
 
 // A dedicated test to cover buffer resize after the size of the next chunk has been received.
 TEST(PosixHTTPServerTest, ChunkedBodyLargeFirstChunk) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("POST", c.HTTPRequest().Method());
                EXPECT_EQ("/", c.HTTPRequest().RawPath());
                c.SendHTTPResponse(c.HTTPRequest().Body());
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
@@ -408,7 +337,6 @@ TEST(PosixHTTPServerTest, ChunkedBodyLargeFirstChunk) {
                       static_cast<int>(body.length()),
                       body.c_str()),
                   connection);
-  test_done = true;
   t.join();
 }
 
@@ -425,18 +353,15 @@ struct HTTPClientImplCURL {
   }
 
   static string Fetch(thread& server_thread,
-                      std::atomic_bool& test_done,
                       const string& url,
                       const string& method) {
     const string result = Syscall(
         strings::Printf("curl -s -X %s localhost:%d%s", method.c_str(), FLAGS_net_http_test_port, url.c_str()));
-    test_done = true;
     server_thread.join();
     return result;
   }
 
   static string FetchWithBody(thread& server_thread,
-                              std::atomic_bool& test_done,
                               const string& url,
                               const string& method,
                               const string& data) {
@@ -445,7 +370,6 @@ struct HTTPClientImplCURL {
                                                   data.c_str(),
                                                   FLAGS_net_http_test_port,
                                                   url.c_str()));
-    test_done = true;
     server_thread.join();
     return result;
   }
@@ -455,23 +379,20 @@ struct HTTPClientImplCURL {
 class HTTPClientImplPOSIX {
  public:
   static string Fetch(thread& server_thread,
-                      std::atomic_bool& test_done,
                       const string& url,
                       const string& method) {
-    return Impl(server_thread, test_done, url, method);
+    return Impl(server_thread, url, method);
   }
 
   static string FetchWithBody(thread& server_thread,
-                              std::atomic_bool& test_done,
                               const string& url,
                               const string& method,
                               const string& data) {
-    return Impl(server_thread, test_done, url, method, true, data);
+    return Impl(server_thread, url, method, true, data);
   }
 
  private:
   static string Impl(thread& server_thread,
-                     std::atomic_bool& test_done,
                      const string& url,
                      const string& method,
                      bool has_data = false,
@@ -490,7 +411,6 @@ class HTTPClientImplPOSIX {
     HTTPRequestData http_request(connection);
     assert(http_request.HasBody());
     const string body = http_request.Body();
-    test_done = true;
     server_thread.join();
     return body;
   }
@@ -507,90 +427,60 @@ typedef ::testing::Types<HTTPClientImplPOSIX> HTTPClientImplsTypeList;
 TYPED_TEST_CASE(HTTPTest, HTTPClientImplsTypeList);
 
 TYPED_TEST(HTTPTest, GET) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("GET", c.HTTPRequest().Method());
                EXPECT_EQ("/unittest?foo=bar", c.HTTPRequest().RawPath());
                EXPECT_EQ("/unittest", c.HTTPRequest().URL().path);
                EXPECT_EQ("bar", c.HTTPRequest().URL().query["foo"]);
                c.SendHTTPResponse("PASSED");
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
-  EXPECT_EQ("PASSED", TypeParam::Fetch(t, test_done, "/unittest?foo=bar", "GET"));
+  EXPECT_EQ("PASSED", TypeParam::Fetch(t, "/unittest?foo=bar", "GET"));
 }
 
 TYPED_TEST(HTTPTest, POST) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("POST", c.HTTPRequest().Method());
                EXPECT_EQ("/unittest_post", c.HTTPRequest().RawPath());
                ASSERT_TRUE(c.HTTPRequest().HasBody()) << "WTF!";
                EXPECT_EQ("BAZINGA", c.HTTPRequest().Body());
                c.SendHTTPResponse("POSTED");
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
-  EXPECT_EQ("POSTED", TypeParam::FetchWithBody(t, test_done, "/unittest_post", "POST", "BAZINGA"));
+  EXPECT_EQ("POSTED", TypeParam::FetchWithBody(t, "/unittest_post", "POST", "BAZINGA"));
 }
 
 TYPED_TEST(HTTPTest, NoBodyPOST) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                EXPECT_EQ("POST", c.HTTPRequest().Method());
                EXPECT_EQ("/unittest_empty_post", c.HTTPRequest().RawPath());
                EXPECT_FALSE(c.HTTPRequest().HasBody());
                ASSERT_THROW(c.HTTPRequest().Body(), HTTPNoBodyProvidedException);
                c.SendHTTPResponse("ALMOST_POSTED");
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
-  EXPECT_EQ("ALMOST_POSTED", TypeParam::Fetch(t, test_done, "/unittest_empty_post", "POST"));
+  EXPECT_EQ("ALMOST_POSTED", TypeParam::Fetch(t, "/unittest_empty_post", "POST"));
 }
 
 TYPED_TEST(HTTPTest, AttemptsToSendResponseTwice) {
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             {
+  thread t([](Socket s) {
                HTTPServerConnection c(s.Accept());
                c.SendHTTPResponse("one");
                ASSERT_THROW(c.SendHTTPResponse("two"), AttemptedToSendHTTPResponseMoreThanOnce);
                ASSERT_THROW(c.SendChunkedHTTPResponse().Send("three"), AttemptedToSendHTTPResponseMoreThanOnce);
-             }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
            },
            Socket(FLAGS_net_http_test_port));
-  EXPECT_EQ("one", TypeParam::Fetch(t, test_done, "/", "GET"));
+  EXPECT_EQ("one", TypeParam::Fetch(t, "/", "GET"));
 }
 
 TYPED_TEST(HTTPTest, DoesNotSendResponseAtAll) {
   EXPECT_EQ("<h1>INTERNAL SERVER ERROR</h1>\n", DefaultInternalServerErrorMessage());
-  std::atomic_bool test_done(false);
-  thread t([&test_done](Socket s) {
-             { HTTPServerConnection c(s.Accept()); }
-             while (!test_done) {
-               ;  // Spin lock.
-             }
-           },
+  thread t([](Socket s) { HTTPServerConnection c(s.Accept()); },
            Socket(FLAGS_net_http_test_port));
-  EXPECT_EQ(DefaultInternalServerErrorMessage(), TypeParam::Fetch(t, test_done, "/", "GET"));
+  EXPECT_EQ(DefaultInternalServerErrorMessage(), TypeParam::Fetch(t, "/", "GET"));
 }
 
 TEST(HTTPCodesTest, SmokeTest) {

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -97,12 +97,12 @@ TEST(PosixHTTPServerTest, Smoke) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("POST / HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("Content-Length: 4\r\n");
-  connection.BlockingWrite("\r\n");
-  connection.BlockingWrite("BODY");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("Content-Length: 4\r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("BODY", true);
+  connection.BlockingWrite("\r\n", false);
   ExpectToReceive(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
@@ -130,10 +130,10 @@ TEST(PosixHTTPServerTest, SmokeWithArray) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("GET /aloha HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("\r\n");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("GET /aloha HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("\r\n", false);
   ExpectToReceive(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
@@ -161,10 +161,10 @@ TEST(PosixHTTPServerTest, SmokeWithObject) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("GET /mahalo HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("\r\n");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("GET /mahalo HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("\r\n", false);
   ExpectToReceive(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
@@ -192,9 +192,9 @@ TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("GET /mahalo HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("GET /mahalo HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("\r\n", false);
   ExpectToReceive(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
@@ -226,9 +226,9 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("GET /chunked HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("GET /chunked HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("\r\n", false);
   ExpectToReceive(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
@@ -265,12 +265,12 @@ TEST(PosixHTTPServerTest, SmokeWithHeaders) {
     },
     Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("GET /header HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("Content-Length: 19\r\n");
-  connection.BlockingWrite("\r\n");
-  connection.BlockingWrite("custom_content_type");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("GET /header HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("Content-Length: 19\r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("custom_content_type", true);
+  connection.BlockingWrite("\r\n", false);
   ExpectToReceive(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: custom_content_type\r\n"
@@ -304,11 +304,11 @@ TEST(PosixHTTPServerTest, LargeBody) {
     body[i] = 'A' + (i % 26);
   }
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("POST / HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite(strings::Printf("Content-Length: %d\r\n", static_cast<int>(body.length())));
-  connection.BlockingWrite("\r\n");
-  connection.BlockingWrite(body);
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite(strings::Printf("Content-Length: %d\r\n", static_cast<int>(body.length())), true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite(body, false);
   ExpectToReceive(
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
@@ -337,22 +337,22 @@ TEST(PosixHTTPServerTest, ChunkedLargeBodyManyChunks) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("POST / HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("Transfer-Encoding: chunked\r\n");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("Transfer-Encoding: chunked\r\n", true);
+  connection.BlockingWrite("\r\n", true);
   string chunk(10, '.');
   string body = "";
   for (size_t i = 0; i < 10000; ++i) {
-    connection.BlockingWrite("A\r\n");  // "A" is hexadecimal for 10.
+    connection.BlockingWrite("A\r\n", true);  // "A" is hexadecimal for 10.
     for (size_t j = 0; j < 10; ++j) {
       chunk[j] = 'A' + ((i + j) % 26);
     }
-    connection.BlockingWrite(chunk);
+    connection.BlockingWrite(chunk, true);
     body += chunk;
-    connection.BlockingWrite("\r\n");
+    connection.BlockingWrite("\r\n", true);
   }
-  connection.BlockingWrite("0\r\n");
+  connection.BlockingWrite("0\r\n", false);
   ExpectToReceive(strings::Printf(
                       "HTTP/1.1 200 OK\r\n"
                       "Content-Type: text/plain\r\n"
@@ -383,21 +383,21 @@ TEST(PosixHTTPServerTest, ChunkedBodyLargeFirstChunk) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("POST / HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("Transfer-Encoding: chunked\r\n");
-  connection.BlockingWrite("\r\n");
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("Transfer-Encoding: chunked\r\n", true);
+  connection.BlockingWrite("\r\n", true);
   string chunk(10000, '.');
   string body = "";
   for (size_t i = 0; i < 10; ++i) {
-    connection.BlockingWrite(strings::Printf("%X\r\n", 10000));
+    connection.BlockingWrite(strings::Printf("%X\r\n", 10000), true);
     for (size_t j = 0; j < 10000; ++j) {
       chunk[j] = 'a' + ((i + j) % 26);
     }
-    connection.BlockingWrite(chunk);
+    connection.BlockingWrite(chunk, true);
     body += chunk;
   }
-  connection.BlockingWrite("0\r\n");
+  connection.BlockingWrite("0\r\n", false);
   ExpectToReceive(strings::Printf(
                       "HTTP/1.1 200 OK\r\n"
                       "Content-Type: text/plain\r\n"
@@ -477,13 +477,15 @@ class HTTPClientImplPOSIX {
                      bool has_data = false,
                      const string& data = "") {
     Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-    connection.BlockingWrite(method + ' ' + url + "\r\n");
+    connection.BlockingWrite(method + ' ' + url + "\r\n", true);
     if (has_data) {
-      connection.BlockingWrite("Content-Length: " + to_string(data.length()) + "\r\n");
+      connection.BlockingWrite("Content-Length: " + to_string(data.length()) + "\r\n", true);
     }
-    connection.BlockingWrite("\r\n");
-    if (has_data) {
-      connection.BlockingWrite(data);
+    if (!has_data) {
+      connection.BlockingWrite("\r\n", false);
+    } else {
+      connection.BlockingWrite("\r\n", true);
+      connection.BlockingWrite(data, false);
     }
     HTTPRequestData http_request(connection);
     assert(http_request.HasBody());
@@ -624,11 +626,11 @@ TEST(HTTPServerTest, ConnectionResetByPeerException) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("POST / HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("Content-Length: 1000000\r\n");
-  connection.BlockingWrite("\r\n");
-  connection.BlockingWrite("This body message terminates prematurely.\r\n");
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("Content-Length: 1000000\r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("This body message terminates prematurely.\r\n", false);
   EXPECT_TRUE(connection_reset_by_peer);
   t.join();
 }
@@ -645,12 +647,12 @@ TEST(PosixHTTPServerTest, ChunkedBodyConnectionResetByPeerException) {
            },
            Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("POST / HTTP/1.1\r\n");
-  connection.BlockingWrite("Host: localhost\r\n");
-  connection.BlockingWrite("Transfer-Encoding: chunked\r\n");
-  connection.BlockingWrite("\r\n");
-  connection.BlockingWrite("10000\r\n");
-  connection.BlockingWrite("This body message terminates prematurely.\r\n");
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("Transfer-Encoding: chunked\r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("10000\r\n, true");
+  connection.BlockingWrite("This body message terminates prematurely.\r\n", false);
   EXPECT_TRUE(connection_reset_by_peer);
   t.join();
 }

--- a/net/tcp/impl/posix.h
+++ b/net/tcp/impl/posix.h
@@ -277,7 +277,7 @@ class Connection : public SocketHandle {
     assert(buffer);
     BRICKS_NET_LOG(
         "S%05d BlockingWrite(%d bytes) ...\n", static_cast<SOCKET>(socket), static_cast<int>(write_length));
-#ifndef BRICKS_WINDOWS
+#if !defined(BRICKS_WINDOWS) && !defined(BRICKS_APPLE)
     const int result =
         static_cast<int>(::send(socket, buffer, write_length, MSG_NOSIGNAL | (more ? MSG_MORE : 0)));
 #else

--- a/net/tcp/impl/posix.h
+++ b/net/tcp/impl/posix.h
@@ -184,7 +184,7 @@ class Connection : public SocketHandle {
   inline typename std::enable_if<sizeof(T) == 1, size_t>::type BlockingRead(
       T* output_buffer, size_t max_length, BlockingReadPolicy policy = BlockingReadPolicy::ReturnASAP) {
     if (max_length == 0) {
-      return 0;
+      return 0;  // LCOV_EXCL_LINE
     } else {
       uint8_t* buffer = reinterpret_cast<uint8_t*>(output_buffer);
       uint8_t* ptr = buffer;
@@ -216,7 +216,7 @@ class Connection : public SocketHandle {
           if ((policy == BlockingReadPolicy::ReturnASAP) || (ptr == end)) {
             return (ptr - buffer);
           } else {
-            continue;
+            continue;  // LCOV_EXCL_LINE
           }
         }
 
@@ -225,8 +225,8 @@ class Connection : public SocketHandle {
 #endif
 
 #ifndef BRICKS_WINDOWS
-        if (errno == EAGAIN) {
-          continue;
+        if (errno == EAGAIN) {  // LCOV_EXCL_LINE
+          continue;             // LCOV_EXCL_LINE
         }
 #else
         if (wsa_last_error == WSAEWOULDBLOCK || wsa_last_error == WSAEINPROGRESS ||
@@ -243,17 +243,17 @@ class Connection : public SocketHandle {
       } while (false);
 
 #ifndef BRICKS_WINDOWS
-      if (errno == ECONNRESET) {
+      if (errno == ECONNRESET) {  // LCOV_EXCL_LINE
         BRICKS_NET_LOG("S%05d BlockingRead() : Connection reset by peer after reading %d bytes.\n",
                        static_cast<SOCKET>(socket),
                        static_cast<int>(ptr - buffer));
-        BRICKS_THROW(ConnectionResetByPeer());
+        BRICKS_THROW(ConnectionResetByPeer());  // LCOV_EXCL_LINE
       } else {
-        BRICKS_NET_LOG("S%05d BlockingRead() : Error after reading %d bytes, errno %d.\n",
+        BRICKS_NET_LOG("S%05d BlockingRead() : Error after reading %d bytes, errno %d.\n",  // LCOV_EXCL_LINE
                        static_cast<SOCKET>(socket),
                        static_cast<int>(ptr - buffer),
                        errno);
-        BRICKS_THROW(SocketReadException());
+        BRICKS_THROW(SocketReadException());  // LCOV_EXCL_LINE
       }
 #else
       if (wsa_last_error == WSAECONNRESET) {

--- a/net/tcp/impl/posix.h
+++ b/net/tcp/impl/posix.h
@@ -169,7 +169,7 @@ class SocketHandle : private SocketSystemInitializer {
 };
 
 class Connection : public SocketHandle {
-public:
+ public:
   inline Connection(SocketHandle&& rhs) : SocketHandle(std::move(rhs)) {}
 
   inline Connection(Connection&& rhs) : SocketHandle(std::move(rhs)) {}
@@ -185,8 +185,7 @@ public:
       T* output_buffer, size_t max_length, BlockingReadPolicy policy = BlockingReadPolicy::ReturnASAP) {
     if (max_length == 0) {
       return 0;
-    }
-    else {
+    } else {
       uint8_t* buffer = reinterpret_cast<uint8_t*>(output_buffer);
       uint8_t* ptr = buffer;
       const uint8_t* end = (buffer + max_length);
@@ -200,12 +199,13 @@ public:
       do {
         const size_t remaining_bytes_to_read = (max_length - (ptr - buffer));
         BRICKS_NET_LOG("S%05d BlockingRead() ... attempting to read %d bytes.\n",
-                        static_cast<SOCKET>(socket),
-                        static_cast<int>(remaining_bytes_to_read));
+                       static_cast<SOCKET>(socket),
+                       static_cast<int>(remaining_bytes_to_read));
 #ifndef BRICKS_WINDOWS
         const ssize_t retval = ::recv(socket, ptr, remaining_bytes_to_read, flags);
 #else
-        const int retval = ::recv(socket, reinterpret_cast<char*>(ptr), static_cast<int>(remaining_bytes_to_read), flags);
+        const int retval =
+            ::recv(socket, reinterpret_cast<char*>(ptr), static_cast<int>(remaining_bytes_to_read), flags);
 #endif
         BRICKS_NET_LOG("S%05d BlockingRead() ... retval = %d, errno = %d.\n",
                        static_cast<SOCKET>(socket),
@@ -215,8 +215,7 @@ public:
           ptr += retval;
           if ((policy == BlockingReadPolicy::ReturnASAP) || (ptr == end)) {
             return (ptr - buffer);
-          }
-          else {
+          } else {
             continue;
           }
         }
@@ -230,7 +229,8 @@ public:
           continue;
         }
 #else
-        if (wsa_last_error == WSAEWOULDBLOCK || wsa_last_error == WSAEINPROGRESS || wsa_last_error == WSAENETDOWN) {
+        if (wsa_last_error == WSAEWOULDBLOCK || wsa_last_error == WSAEINPROGRESS ||
+            wsa_last_error == WSAENETDOWN) {
           // Effectively, `errno == EAGAIN`.
           continue;
         }
@@ -248,8 +248,7 @@ public:
                        static_cast<SOCKET>(socket),
                        static_cast<int>(ptr - buffer));
         BRICKS_THROW(ConnectionResetByPeer());
-      }
-      else {
+      } else {
         BRICKS_NET_LOG("S%05d BlockingRead() : Error after reading %d bytes, errno %d.\n",
                        static_cast<SOCKET>(socket),
                        static_cast<int>(ptr - buffer),
@@ -263,8 +262,7 @@ public:
                        static_cast<SOCKET>(socket),
                        static_cast<int>(ptr - buffer));
         BRICKS_THROW(ConnectionResetByPeer());
-      }
-      else {
+      } else {
         BRICKS_NET_LOG("S%05d BlockingRead() : Error after reading %d bytes, errno %d.\n",
                        static_cast<SOCKET>(socket),
                        static_cast<int>(ptr - buffer),

--- a/net/tcp/impl/posix.h
+++ b/net/tcp/impl/posix.h
@@ -178,7 +178,7 @@ class Connection : public SocketHandle {
   // with the exception being multibyte records (sizeof(T) > 1), where it will keep reading
   // until the boundary of the records, or max_length of them, has been read.
   // Alternatively, the 3rd parameter can be explicitly set to BlockingReadPolicy::FillFullBuffer,
-  // which will cause BlockingRead() to keep reading more data until all `max_elements` are read or EOF is hit.
+  // which will cause BlockingRead() to keep reading more data until all `max_elements` are read.
   enum BlockingReadPolicy { ReturnASAP = false, FillFullBuffer = true };
   template <typename T>
   inline typename std::enable_if<sizeof(T) == 1, size_t>::type BlockingRead(

--- a/net/tcp/test.cc
+++ b/net/tcp/test.cc
@@ -78,7 +78,7 @@ static void ExpectFromSocket(const std::string& golden,
                              const string& message_to_send_from_client = "") {
   ExpectFromSocket(golden, server_thread, host, port, [&message_to_send_from_client](Connection& connection) {
     if (!message_to_send_from_client.empty()) {
-      connection.BlockingWrite(message_to_send_from_client);
+      connection.BlockingWrite(message_to_send_from_client, true);
     }
   });
 }
@@ -96,46 +96,89 @@ static void ExpectFromSocket(const std::string& golden,
 }
 
 TEST(TCPTest, ReceiveMessage) {
-  thread server([](Socket socket) { socket.Accept().BlockingWrite("BOOM"); }, Socket(FLAGS_net_tcp_test_port));
+  thread server([](Socket socket) { socket.Accept().BlockingWrite("BOOM", true); },
+                Socket(FLAGS_net_tcp_test_port));
   ExpectFromSocket("BOOM", server);
 }
 
+TEST(TCPTest, ReceiveMessageOfTwoParts) {
+  thread server([](Socket socket) { socket.Accept().BlockingWrite("BOO", false).BlockingWrite("M", true); },
+                Socket(FLAGS_net_tcp_test_port));
+  ExpectFromSocket("BOOM", server);
+}
+
+TEST(TCPTest, ReceiveDelayedMessage) {
+  thread server([](Socket socket) {
+                  Connection connection = socket.Accept();
+                  connection.BlockingWrite("BLA", false);
+                  sleep_for(milliseconds(1));
+                  connection.BlockingWrite("H", true);
+                },
+                Socket(FLAGS_net_tcp_test_port));
+  Connection client(ClientSocket("localhost", FLAGS_net_tcp_test_port));
+  char response[5] = "????";
+  ASSERT_EQ(4u, client.BlockingRead(response, 4, Connection::FillFullBuffer));
+  EXPECT_EQ("BLAH", std::string(response));
+  server.join();
+}
+
+TEST(TCPTest, ReceiveMessageAsResponse) {
+  thread server([](Socket socket) {
+                  Connection connection = socket.Accept();
+                  connection.BlockingWrite("{", false);
+                  char buffer[2];  // Wait for three incoming bytes before sending data out.
+                  ASSERT_EQ(2u, connection.BlockingRead(buffer, 2, Connection::FillFullBuffer));
+                  connection.BlockingWrite(buffer, 2, false);
+                  connection.BlockingWrite("}", true);
+                },
+                Socket(FLAGS_net_tcp_test_port));
+  Connection client(ClientSocket("localhost", FLAGS_net_tcp_test_port));
+  client.BlockingWrite("!?", true);
+  char response[5] = "????";
+  ASSERT_EQ(4u, client.BlockingRead(response, 4, Connection::FillFullBuffer));
+  EXPECT_EQ("{!?}", std::string(response));
+  server.join();
+}
+
+// TODO(dkorolev): Sometimes this test takes 200ms, figure out why.
 TEST(TCPTest, CanNotUseMovedAwayConnection) {
   thread server([](Socket socket) {
                   Connection connection = socket.Accept();
-                  char buffer[3];  // Wait for three incoming bytes before sending data out.
-                  connection.BlockingRead(buffer, 3, Connection::FillFullBuffer);
-                  connection.BlockingWrite("OK");
+                  char buffer[2];  // Wait for three incoming bytes before sending data out.
+                  ASSERT_EQ(2u, connection.BlockingRead(buffer, 2, Connection::FillFullBuffer));
+                  connection.BlockingWrite("OK", true);
                 },
                 Socket(FLAGS_net_tcp_test_port));
   Connection old_connection(ClientSocket("localhost", FLAGS_net_tcp_test_port));
-  old_connection.BlockingWrite("1");
+  old_connection.BlockingWrite("1", false);
   Connection new_connection(std::move(old_connection));
-  new_connection.BlockingWrite("22");
-  ASSERT_THROW(old_connection.BlockingWrite("333"), AttemptedToUseMovedAwayConnection);
+  ASSERT_THROW(old_connection.BlockingWrite("333", false), AttemptedToUseMovedAwayConnection);
+  char tmp[3];
+  ASSERT_THROW(old_connection.BlockingRead(tmp, 3), AttemptedToUseMovedAwayConnection);
+  new_connection.BlockingWrite("2", true);
   char response[3] = "WA";
-  ASSERT_THROW(old_connection.BlockingRead(response, 3), AttemptedToUseMovedAwayConnection);
-  server.join();
   ASSERT_EQ(2u, new_connection.BlockingRead(response, 2, Connection::FillFullBuffer));
   EXPECT_EQ("OK", std::string(response));
+  server.join();
 }
 
 TEST(TCPTest, ReceiveMessageOfTwoUInt16) {
   // Note: This tests endianness as well -- D.K.
   thread server_thread([](Socket socket) {
-                         socket.Accept().BlockingWrite(vector<uint16_t>{0x3031, 0x3233});
+                         socket.Accept().BlockingWrite(vector<uint16_t>{0x3031, 0x3233}, true);
                        },
                        Socket(FLAGS_net_tcp_test_port));
   ExpectFromSocket("1032", server_thread);
 }
 
+// TODO(dkorolev): Sometimes this test takes 200ms, figure out why.
 TEST(TCPTest, EchoMessage) {
   thread server_thread([](Socket socket) {
                          Connection connection(socket.Accept());
                          std::vector<char> s(7);
                          ASSERT_EQ(s.size(),
                                    connection.BlockingRead(&s[0], s.size(), Connection::FillFullBuffer));
-                         connection.BlockingWrite("ECHO: " + std::string(s.begin(), s.end()));
+                         connection.BlockingWrite("ECHO: " + std::string(s.begin(), s.end()), true);
                        },
                        Socket(FLAGS_net_tcp_test_port));
   ExpectFromSocket("ECHO: TEST OK", server_thread, std::string("TEST OK"));
@@ -149,17 +192,17 @@ TEST(TCPTest, EchoThreeMessages) {
                          for (int i = 0; i < 3; ++i) {
                            ASSERT_EQ(block_length,
                                      connection.BlockingRead(&s[0], block_length, Connection::FillFullBuffer));
-                           connection.BlockingWrite(i > 0 ? "," : "ECHO: ");
-                           connection.BlockingWrite(s);
+                           connection.BlockingWrite(i > 0 ? "," : "ECHO: ", false);
+                           connection.BlockingWrite(s, true);
                          }
                        },
                        Socket(FLAGS_net_tcp_test_port));
   ExpectFromSocket("ECHO: FOO,BAR,BAZ", server_thread, [](Connection& connection) {
-    connection.BlockingWrite("FOOBARB");
+    connection.BlockingWrite("FOOBARB", false);
     sleep_for(milliseconds(1));
-    connection.BlockingWrite("A");
+    connection.BlockingWrite("A", false);
     sleep_for(milliseconds(1));
-    connection.BlockingWrite("Z");
+    connection.BlockingWrite("Z", true);
   });
 }
 
@@ -169,7 +212,7 @@ TEST(TCPTest, EchoLongMessageTestsDynamicBufferGrowth) {
                          std::vector<char> s(10000);
                          ASSERT_EQ(s.size(),
                                    connection.BlockingRead(&s[0], s.size(), Connection::FillFullBuffer));
-                         connection.BlockingWrite("ECHO: " + std::string(s.begin(), s.end()));
+                         connection.BlockingWrite("ECHO: " + std::string(s.begin(), s.end()), true);
                        },
                        Socket(FLAGS_net_tcp_test_port));
   std::string message;
@@ -202,12 +245,12 @@ TEST(TCPTest, WriteExceptionWhileWritingAVeryLongMessage) {
                          Connection connection(socket.Accept());
                          char buffer[3];
                          connection.BlockingRead(buffer, 3, Connection::FillFullBuffer);
-                         connection.BlockingWrite("Done, thanks.\n");
+                         connection.BlockingWrite("Done, thanks.\n", true);
                        },
                        Socket(FLAGS_net_tcp_test_port));
   // Attempt to send a very long message to ensure it does not fit OS buffers.
   Connection connection(ClientSocket("localhost", FLAGS_net_tcp_test_port));
-  ASSERT_THROW(connection.BlockingWrite(std::vector<char>(10 * 1000 * 1000, '!')),
+  ASSERT_THROW(connection.BlockingWrite(std::vector<char>(10 * 1000 * 1000, '!'), true),
                SocketCouldNotWriteEverythingException);
   server_thread.join();
 }

--- a/net/tcp/test.cc
+++ b/net/tcp/test.cc
@@ -142,7 +142,6 @@ TEST(TCPTest, ReceiveMessageAsResponse) {
   server.join();
 }
 
-// TODO(dkorolev): Sometimes this test takes 200ms, figure out why.
 TEST(TCPTest, CanNotUseMovedAwayConnection) {
   thread server([](Socket socket) {
                   Connection connection = socket.Accept();
@@ -173,7 +172,6 @@ TEST(TCPTest, ReceiveMessageOfTwoUInt16) {
   ExpectFromSocket("1032", server_thread);
 }
 
-// TODO(dkorolev): Sometimes this test takes 200ms, figure out why.
 TEST(TCPTest, EchoMessage) {
   thread server_thread([](Socket socket) {
                          Connection connection(socket.Accept());

--- a/net/tcp/test.cc
+++ b/net/tcp/test.cc
@@ -145,8 +145,8 @@ TEST(TCPTest, ReceiveMessageAsResponse) {
 TEST(TCPTest, CanNotUseMovedAwayConnection) {
   thread server([](Socket socket) {
                   Connection connection = socket.Accept();
-                  char buffer[2];  // Wait for three incoming bytes before sending data out.
-                  ASSERT_EQ(2u, connection.BlockingRead(buffer, 2, Connection::FillFullBuffer));
+                  char buffer[3];  // Wait for three incoming bytes before sending data out.
+                  ASSERT_EQ(3u, connection.BlockingRead(buffer, 3, Connection::FillFullBuffer));
                   connection.BlockingWrite("OK", false);
                 },
                 Socket(FLAGS_net_tcp_test_port));
@@ -156,7 +156,7 @@ TEST(TCPTest, CanNotUseMovedAwayConnection) {
   ASSERT_THROW(old_connection.BlockingWrite("333", true), AttemptedToUseMovedAwayConnection);
   char tmp[3];
   ASSERT_THROW(old_connection.BlockingRead(tmp, 3), AttemptedToUseMovedAwayConnection);
-  new_connection.BlockingWrite("2", false);
+  new_connection.BlockingWrite("22", false);
   char response[3] = "WA";
   ASSERT_EQ(2u, new_connection.BlockingRead(response, 2, Connection::FillFullBuffer));
   EXPECT_EQ("OK", std::string(response));


### PR DESCRIPTION
Hi!

First off, I'm officially an underqualified network programmer. The problem was solved by telling `::send()` that more data is there to come, by passing `MSG_MORE` as `flags` when there is more data to come. I have made the necessary changes; please take a look on whether I missed any of those and/or did them wrong.

Also, `MSG_WAITALL` for `::recv()` does (most of) the trick with synchronous receive. I've made use of it too. So, two network programming blunders. So much for good architecture. :-(

Now, state of the art.

`net/tcp` and `net/api` are stable.

I've run them with `--gtest_repeat=10000 --gtest_break_on_failure` both on Linux (`-O3` and `-g`) and on Windows (`x64/Debug` and `x64/Release).

(Although with the most recent change, `--gtest_break_on_failure` defaults to `true`, and is thus optional.)

I even ran them with `--gtest_filter=*Smoke*` / `--gtest_filter=*Smoke*`, to only run the simplest and fastest tests (fast cycles have been showing random issues before on 1'000+ iterations. Btw, on Linux Bricks is showing >1K QPS on basic `tcp/http/api` tests, even on the ones parsing the URL.)

The `het/http` test is stable on Linux, with all the above statements about stress testing being true.

On Windows though, the `net/http` test can be made fail. It happens **only** in `Release` mode, and only when running the binary outside the IDE; in other words, it's not debuggable. :-1: It is, however, consistently repeatable; the following command does it: `Bricks\VisualStudioSolution\x64\Release> .\net_http.exe --gtest_repeat=1000 --gtest_filter=*Smoke`. On my desktop this command fails within a second; sometimes on the 2nd or 3rd, sometimes on 100++-th iteration, but still within a second.

I have narrowed the issue to the client thread not being able to read the expected response from the socket. The exception is either `SocketReadException` or `ConnectionResetByPeer`, with no apparent pattern.

With respect to this problem, I am close to giving up since a) it is low-pri, b) it is a bit too deep, and c) interestingly, all `net/api` tests, which are what our users would use, pass like a Swiss watch.

One reasonable explanation may be that `net/api` opens the listener socket on the specified port once per binary, while `net/http` tests re-open it for each test. Perhaps some form of `flush()` w.r.t. waiting for internal buffers per port to get released, might do this trick. Another point to support this theory it that `net/api` perform much better QPS-wise than the ones in `net/tcp` or `net/http`, despite the latter ones being more trivial.

(A relatively simple test might me to run `WSAStartup()/WSAShutdown()` per each test, not once per binary. But it's 3am.)

@deathbaba : Please review. Thanks!

@mzhurovich : Thanks for volunteering to look into! An extra pair of `C++`-savvy eyes certainly won't hurt :+1:

@sompylasar : Sorry man, I've changed `Blocking{Read/Write}` once again. Hope it doesn't affect your REPL code much; in my defense, the changes are probably either irrelevant to your code or making it simpler.