### PR TITLE
Minor extensions to net/.

### DIFF
--- a/net/api/docu/server/docu_03httpserver_04_test.cc
+++ b/net/api/docu/server/docu_03httpserver_04_test.cc
@@ -93,12 +93,12 @@ HTTP(port).ResetAllHandlers();
       }
     }
   });
-EXPECT_EQ("{\"value0\":{\"error\":\"\",\"result\":5}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"add",{2,3},""})).body);
-EXPECT_EQ("{\"value0\":{\"error\":\"\",\"result\":6}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"mul",{2,3},""})).body);
-EXPECT_EQ("{\"value0\":{\"error\":\"Unknown operation: sqrt\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"sqrt",{},""})).body);
-EXPECT_EQ("{\"value0\":{\"error\":\"Not enough arguments for 'add'.\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"add",{},""})).body);
-EXPECT_EQ("{\"value0\":{\"error\":\"Not enough arguments for 'mul'.\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"mul",{},""})).body);
-EXPECT_EQ("{\"value0\":{\"error\":\"JSON parse error: FFFUUUUU\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), "FFFUUUUU", "text/plain")).body);
+EXPECT_EQ("{\"data\":{\"error\":\"\",\"result\":5}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"add",{2,3},""})).body);
+EXPECT_EQ("{\"data\":{\"error\":\"\",\"result\":6}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"mul",{2,3},""})).body);
+EXPECT_EQ("{\"data\":{\"error\":\"Unknown operation: sqrt\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"sqrt",{},""})).body);
+EXPECT_EQ("{\"data\":{\"error\":\"Not enough arguments for 'add'.\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"add",{},""})).body);
+EXPECT_EQ("{\"data\":{\"error\":\"Not enough arguments for 'mul'.\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), PennyInput{"mul",{},""})).body);
+EXPECT_EQ("{\"data\":{\"error\":\"JSON parse error: FFFUUUUU\",\"result\":0}}\n", HTTP(POST(Printf("http://localhost:%d/penny", port), "FFFUUUUU", "text/plain")).body);
 }
 
 #endif  // BRICKS_NET_API_DOCU_SERVER_04_TEST_CC

--- a/net/http/impl/server.h
+++ b/net/http/impl/server.h
@@ -442,7 +442,7 @@ class HTTPServerConnection final {
       const std::string& content_type = DefaultJSONContentType(),
       const HTTPHeadersType& extra_headers = DefaultJSONHTTPHeaders()) {
     // TODO(dkorolev): We should probably make this not only correct but also efficient.
-    const std::string s = cerealize::JSON(object) + '\n';
+    const std::string s = cerealize::JSON(object, "data") + '\n';
     SendHTTPResponseImpl(s.begin(), s.end(), code, content_type, extra_headers);
   }
 
@@ -502,7 +502,7 @@ class HTTPServerConnection final {
       // Support objects that can be serialized as JSON-s via Cereal.
       template <class T>
       inline typename std::enable_if<cerealize::is_cerealizable<T>::value>::type Send(T&& object) {
-        SendImpl(cerealize::JSON(object) + '\n');
+        SendImpl(cerealize::JSON(object, "data") + '\n');
       }
       template <class T, typename S>
       inline typename std::enable_if<cerealize::is_cerealizable<T>::value>::type Send(T&& object, S&& name) {

--- a/net/http/test.cc
+++ b/net/http/test.cc
@@ -147,9 +147,9 @@ TEST(PosixHTTPServerTest, SmokeWithObject) {
       "Content-Type: application/json; charset=utf-8\r\n"
       "Connection: close\r\n"
       "Access-Control-Allow-Origin: *\r\n"
-      "Content-Length: 55\r\n"
+      "Content-Length: 53\r\n"
       "\r\n"
-      "{\"value0\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n",
+      "{\"data\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n",
       connection);
   t.join();
 }
@@ -205,8 +205,8 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
       "onetwothree\r\n"
       "3\r\n"
       "foo\r\n"
-      "37\r\n"
-      "{\"value0\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n\r\n"
+      "35\r\n"
+      "{\"data\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n\r\n"
       "3B\r\n"
       "{\"epic_chunk\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n\r\n"
       "0\r\n",

--- a/net/url/test.cc
+++ b/net/url/test.cc
@@ -170,6 +170,16 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("value2", u.query["key2"]);
     EXPECT_EQ("value2", u.query.get("key2", "default_value"));
     EXPECT_EQ("http://www.google.com/q?key=value&key2=value2#fragment#foo", u.ComposeURL());
+    const auto& as_map = u.AllQueryParameters();
+    EXPECT_EQ(2u, as_map.size());
+    const auto key = as_map.find("key");
+    const auto key2 = as_map.find("key2");
+    const auto key3 = as_map.find("key3");
+    ASSERT_TRUE(key != as_map.end());
+    ASSERT_TRUE(key2 != as_map.end());
+    ASSERT_TRUE(key3 == as_map.end());
+    EXPECT_EQ("value", key->second);
+    EXPECT_EQ("value2", key2->second);
   }
   {
     URL u("www.google.com/a?k=a%3Db%26s%3D%25s%23#foo");

--- a/net/url/url.h
+++ b/net/url/url.h
@@ -247,8 +247,11 @@ struct URLParametersExtractor {
         return default_value;
       }
     }
+    const std::map<std::string, std::string>& AsImmutableMap() const { return parameters_; }
     std::map<std::string, std::string> parameters_;
   };
+
+  const std::map<std::string, std::string>& AllQueryParameters() const { return query.AsImmutableMap(); }
 
   std::vector<std::pair<std::string, std::string>> parameters_vector;
   QueryParameters query;


### PR DESCRIPTION
Rename `"value0"` into `"data"` by default.
Exposed URL query parameters as a `map<string, string>`.

This PR goes together with https://github.com/KnowSheet/SimpleServer/pull/1.