### PR TITLE
Fixed Cerealize file scoping + indent + minor.

### DIFF
--- a/cerealize/cerealize.h
+++ b/cerealize/cerealize.h
@@ -149,13 +149,11 @@ enum class CerealFormat { Default = 0, Binary = 0, JSON };
 class CerealFileAppenderBase {
  public:
   explicit CerealFileAppenderBase(const std::string& filename, bool append = true)
-       : fo_(filename, (append ? std::ofstream::app : std::ofstream::trunc) | std::ofstream::binary),
-         initial_stream_position_(fo_.tellp()) {}
+      : fo_(filename, (append ? std::ofstream::app : std::ofstream::trunc) | std::ofstream::binary),
+        initial_stream_position_(fo_.tellp()) {}
 
   inline size_t EntriesAppended() const { return entries_appended_; }
-  inline size_t BytesAppended() const {
-      return current_stream_position() - initial_stream_position_;
-  }
+  inline size_t BytesAppended() const { return current_stream_position() - initial_stream_position_; }
   inline size_t TotalFileSize() const { return current_stream_position(); }
 
  protected:
@@ -188,8 +186,7 @@ class CerealFileAppenderBase {
 class CerealBinaryFileAppender : public CerealFileAppenderBase {
  public:
   explicit CerealBinaryFileAppender(const std::string& filename, bool append = true)
-      : CerealFileAppenderBase(filename, append),
-        so_(cereal::BinaryOutputArchive(fo_)) {}
+      : CerealFileAppenderBase(filename, append), so_(cereal::BinaryOutputArchive(fo_)) {}
 
   template <typename T>
   typename std::enable_if<sizeof(typename T::CEREAL_BASE_TYPE) != 0, CerealBinaryFileAppender&>::type
@@ -214,8 +211,8 @@ class CerealJSONFileAppender : public CerealFileAppenderBase {
       : CerealFileAppenderBase(filename, append) {}
 
   template <typename T>
-  typename std::enable_if<sizeof(typename T::CEREAL_BASE_TYPE) != 0, CerealJSONFileAppender&>::type
-  operator<<(const T& entry) {
+  typename std::enable_if<sizeof(typename T::CEREAL_BASE_TYPE) != 0, CerealJSONFileAppender&>::type operator<<(
+      const T& entry) {
     // One entry per line format.
     // JSONOutputArchive writes the final '}' after going out of the scope.
     {
@@ -241,7 +238,7 @@ struct CerealGenericFileAppender<CerealFormat::JSON> {
   typedef CerealJSONFileAppender type;
 };
 
-template <CerealFormat T_FORMAT = CerealFormat::Default> 
+template <CerealFormat T_FORMAT = CerealFormat::Default>
 using CerealFileAppender = typename CerealGenericFileAppender<T_FORMAT>::type;
 
 // `CerealBinaryFileParser` de-cereal-izes records from binary file given their type
@@ -296,8 +293,7 @@ class CerealBinaryFileParser {
   cereal::BinaryInputArchive si_;
 };
 
-
-// `CerealJSONFileParser` de-cereal-izes records from JSON file given their type 
+// `CerealJSONFileParser` de-cereal-izes records from JSON file given their type
 // and passes them over to `T_PROCESSOR`. Each line in the file expected to be a
 // full JSON record for one entry.
 template <typename T_ENTRY>

--- a/cerealize/test.cc
+++ b/cerealize/test.cc
@@ -143,14 +143,18 @@ TEST(Cerealize, BinarySerializesAndParses) {
   EventAppSuspend b;
   EventAppResume c;
 
-  CerealFileAppender<CerealFormat::Binary> f1(CurrentTestTempFileName());
-  f1 << a << b;
-  EXPECT_EQ(2u, f1.EntriesAppended());
-  EXPECT_EQ(115u, f1.BytesAppended());
-  CerealFileAppender<CerealFormat::Binary> f2(CurrentTestTempFileName());
-  f2 << c;
-  EXPECT_EQ(1u, f2.EntriesAppended());
-  EXPECT_EQ(58u, f2.BytesAppended());
+  {
+    CerealFileAppender<CerealFormat::Binary> f1(CurrentTestTempFileName());
+    f1 << a << b;
+    EXPECT_EQ(2u, f1.EntriesAppended());
+    EXPECT_EQ(115u, f1.BytesAppended());
+  }
+  {
+    CerealFileAppender<CerealFormat::Binary> f2(CurrentTestTempFileName());
+    f2 << c;
+    EXPECT_EQ(1u, f2.EntriesAppended());
+    EXPECT_EQ(58u, f2.BytesAppended());
+  }
 
   CerealFileParser<MapsYouEventBase, CerealFormat::Binary> f(CurrentTestTempFileName());
 
@@ -173,15 +177,19 @@ TEST(Cerealize, JSONSerializesAndParses) {
   EventAppSuspend b;
   EventAppResume c;
 
-  CerealFileAppender<CerealFormat::JSON> f1(CurrentTestTempFileName());
-  f1 << a;
-  EXPECT_EQ(1u, f1.EntriesAppended());
-  EXPECT_EQ(169u, f1.BytesAppended());
-  CerealFileAppender<CerealFormat::JSON> f2(CurrentTestTempFileName());
-  f2 << b << c;
-  EXPECT_EQ(2u, f2.EntriesAppended());
-  EXPECT_EQ(340u, f2.BytesAppended());
-  EXPECT_EQ(509u, f2.TotalFileSize());
+  {
+    CerealFileAppender<CerealFormat::JSON> f1(CurrentTestTempFileName());
+    f1 << a;
+    EXPECT_EQ(1u, f1.EntriesAppended());
+    EXPECT_EQ(169u, f1.BytesAppended());
+  }
+  {
+    CerealFileAppender<CerealFormat::JSON> f2(CurrentTestTempFileName());
+    f2 << b << c;
+    EXPECT_EQ(2u, f2.EntriesAppended());
+    EXPECT_EQ(340u, f2.BytesAppended());
+    EXPECT_EQ(509u, f2.TotalFileSize());
+  }
 
   CerealFileParser<MapsYouEventBase, CerealFormat::JSON> f(CurrentTestTempFileName());
 

--- a/net/api/impl/posix_client.h
+++ b/net/api/impl/posix_client.h
@@ -202,7 +202,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
                                  HTTPResponseWithBuffer& output) {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));
     const auto& http_request = response.HTTPRequest();
-    output.body = http_request.HasBody() ? http_request.Body() : "";
+    output.body = http_request.Body();
   }
 
   template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
@@ -213,8 +213,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));
     // TODO(dkorolev): This is doubly inefficient. Should write the buffer or write in chunks instead.
     const auto& http_request = response.HTTPRequest();
-    FileSystem::WriteStringToFile(http_request.HasBody() ? http_request.Body() : "",
-                                  response_params.file_name.c_str());
+    FileSystem::WriteStringToFile(http_request.Body(), response_params.file_name.c_str());
     output.body_file_name = response_params.file_name;
   }
 };

--- a/net/api/test.cc
+++ b/net/api/test.cc
@@ -509,12 +509,13 @@ TEST(HTTPAPI, PostFromFileToFile) {
 
 TEST(HTTPAPI, PutCerealizableObject) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port).Register("/put", [](Request r) {                                         
+  HTTP(FLAGS_net_api_test_port).Register("/put", [](Request r) {
     EXPECT_EQ("PUT", r.method);
     ASSERT_FALSE(r.body.empty());
     r(r.body, HTTPResponseCode.Created);
   });
-  const auto response = HTTP(PUT(Printf("http://localhost:%d/put", FLAGS_net_api_test_port), SerializableObject()));
+  const auto response =
+      HTTP(PUT(Printf("http://localhost:%d/put", FLAGS_net_api_test_port), SerializableObject()));
   EXPECT_EQ("{\"data\":{\"x\":42,\"s\":\"foo\"}}", response.body);
   EXPECT_EQ(201, static_cast<int>(response.code));
 }

--- a/net/http/impl/server.h
+++ b/net/http/impl/server.h
@@ -283,13 +283,9 @@ class TemplatedHTTPRequestData : public HELPER {
     return *prepared_body_.get();
   }
 
-  inline const char* BodyBegin() const {
-    return body_buffer_begin_;
-  }
+  inline const char* BodyBegin() const { return body_buffer_begin_; }
 
-  inline const char* BodyEnd() const {
-    return body_buffer_end_;
-  }
+  inline const char* BodyEnd() const { return body_buffer_end_; }
 
   inline size_t BodyLength() const {
     if (body_buffer_begin_) {


### PR DESCRIPTION
@mzhurovich : PTAL.

@deathbaba : FYI + warning/note: Concurrent file opening is indeed a problem. For instance, in the case fixed by this pull request, was unseen on Mac, yet showed up on Ubuntu.

Thanks,
Dima
