### PR TITLE
Fixed chunked transfer in HTTP server.

### DIFF
--- a/net/api/test.cc
+++ b/net/api/test.cc
@@ -272,8 +272,6 @@ struct ShouldReduceDelayBetweenChunksSingleton {
   bool yes = false;
 };
 // Test various HTTP client modes.
-#ifndef BRICKS_APPLE
-// Temporary disabled chunked-transfer test for Apple -- M.Z.
 TEST(HTTPAPI, GetToFile) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   HTTP(FLAGS_net_api_test_port).Register("/stars", [](Request r) {
@@ -311,7 +309,6 @@ TEST(HTTPAPI, GetToFile) {
   EXPECT_EQ(url, response.url);
   EXPECT_EQ("*ab12*ab12*ab12", FileSystem::ReadFileAsString(response.body_file_name));
 }
-#endif
 
 TEST(HTTPAPI, PostFromBufferToBuffer) {
   HTTP(FLAGS_net_api_test_port).ResetAllHandlers();

--- a/net/http/impl/server.h
+++ b/net/http/impl/server.h
@@ -455,6 +455,7 @@ class HTTPServerConnection final {
         try {
           connection_.BlockingWrite("0", true);
           connection_.BlockingWrite(kCRLF, false);
+          connection_.BlockingWrite(kCRLF, false);  // We should send CRLF twice.
         } catch (const std::exception& e) {  // LCOV_EXCL_LINE
           // TODO(dkorolev): More reliable logging.
           std::cerr << "Chunked response closure failed: " << e.what() << std::endl;  // LCOV_EXCL_LINE


### PR DESCRIPTION
Small but important fix to make server more standard-compliant and to allow Mac client properly parse chunked responses (Sherlock's test failed before that).
@dkorolev PTAL