### PR TITLE
The combiner now supports overlapping classes.

### DIFF
--- a/template/combine.h
+++ b/template/combine.h
@@ -1,0 +1,81 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BRICKS_TEMPLATE_COMBINE_H
+#define BRICKS_TEMPLATE_COMBINE_H
+
+#include <tuple>
+#include <utility>
+
+namespace bricks {
+namespace metaprogramming {
+
+// `combine<std::tuple<A, B, C>>` == a `struct` that internally contains all `A`, `B` and `C`
+// via "has-a" inheritance, and exposes `operator()`, calls to which compile-time dispatched
+// to the instances of `A`, `B` or `C` respectively, based on type signature.
+// No matching invocation signature will result in compile-time error, same as the case
+// of more than one invocation signature matching the call.
+
+template <typename T>
+struct dispatch {
+  T has_a_instance;
+
+  template <typename... XS>
+  static constexpr bool sfinae(char) {
+    return false;
+  }
+
+  template <typename... XS>
+  static constexpr auto sfinae(int) -> decltype(std::declval<T>()(std::declval<XS>()...), bool()) {
+    return true;
+  }
+
+  template <typename... XS>
+  typename std::enable_if<sfinae<XS...>(0), decltype(std::declval<T>()(std::declval<XS>()...))>::type
+  operator()(XS... params) {
+    return has_a_instance(params...);
+  }
+};
+
+template <typename T1, typename T2>
+struct inherit_from_both : T1, T2 {
+  using T1::operator();
+  using T2::operator();
+  // Note: clang++ passes `operator`-s through
+  // by default, whereas g++ requires `using`-s. --  D.K.
+};
+
+template <typename T>
+struct combine {};
+
+template <typename T>
+struct combine<std::tuple<T>> : dispatch<T> {};
+
+template <typename T, typename... TS>
+struct combine<std::tuple<T, TS...>> : inherit_from_both<dispatch<T>, combine<std::tuple<TS...>>> {};
+
+}  // namespace metaprogramming
+}  // namespace bricks
+
+#endif  // BRICKS_TEMPLATE_COMBINE_H

--- a/template/docu/docu_05metaprogramming_02.cc
+++ b/template/docu/docu_05metaprogramming_02.cc
@@ -83,19 +83,105 @@ TEST(TemplateMetaprogramming, Reduce) {
             (bricks::metaprogramming::reduce<concatenate_s, std::tuple<A, B, C>>::s()));
 }
     
+template <typename T> struct AsIntImpl {};
+template <> struct AsIntImpl<int> { static int DoIt(int x) { return x; } };
+template <> struct AsIntImpl<const char*> { static int DoIt(const char* s) { return atoi(s); } };
+template <typename T> int AsInt(T x) { return AsIntImpl<T>::DoIt(x); }
+
   // Combine.
+  struct NEG {
+    // A simple way to differentiate logic by struct/class type
+    // is to provide a local, unique, symbol as the 1st param.
+    struct TYPE {};
+
+    // Combine-able operations are defined as `operator()`.
+    // Just because we need to pick one common name,
+    // otherwise more `using`-s will be needed.
+    int operator()(TYPE, int a) { return -a; }
+  };
+  
+  struct ADD {
+    struct TYPE {};
+    int operator()(TYPE, int a, int b) { return a + b; }
+    // Prove that the method is instantiated at compile time.
+    template <typename T>
+    int operator()(TYPE, int a, int b, T c) {
+      return a + b + AsInt(c);
+    }
+  };
+  
+  // Since "has-a" is used instead of "is-a",
+  // mutual inheritance of underlying types
+  // is not a problem at all.
+  // Confirm this by making `MUL` inherit from `ADD`.
+  struct MUL : ADD {
+    struct TYPE {};
+    int operator()(TYPE, int a, int b) { return a * b; }
+    int operator()(TYPE, int a, int b, int c) { return a * b * c; }
+  };
+    
+  // User-friendly method names, internally dispatching calls via `operator()`.
+  // A good way to make sure new names appear in one place only, since
+  // using `using`-s would require writing them down at least twice each.
+  struct UserFriendlyArithmetics :
+      bricks::metaprogramming::combine<std::tuple<NEG, ADD, MUL>> {
+    int Neg(int x) {
+      return operator()(NEG::TYPE(), x);
+    }
+    template <typename... T>
+    int Add(T... xs) {
+      return operator()(ADD::TYPE(), xs...);
+    }
+    template <typename... T>
+    int Mul(T... xs) {
+      return operator()(MUL::TYPE(), xs...);
+    }
+    // The implementation for `Div()` is not provided,
+    // yet the code will compile until it's attempted to be used.
+    // (Unit tests and code coverage measurement FTW!)
+    template <typename... T>
+    int Div(T... xs) {
+      struct TypeForWhichThereIsNoImplemenation {};
+      return operator()(TypeForWhichThereIsNoImplemenation(),
+                        xs...);
+    }
+  };
+
 TEST(TemplateMetaprogramming, Combine) {
-  struct A { static std::string foo() { return "foo"; } };
-  struct B { static std::string bar() { return "bar"; } };
-  struct C { static std::string baz() { return "baz"; } };
+  EXPECT_EQ(1, NEG()(NEG::TYPE(), -1));
+  EXPECT_EQ(3, ADD()(ADD::TYPE(), 1, 2));
+  EXPECT_EQ(6, ADD()(ADD::TYPE(), 1, 2, "3"));
+  EXPECT_EQ(20, MUL()(MUL::TYPE(), 4, 5));
+  EXPECT_EQ(120, MUL()(MUL::TYPE(), 4, 5, 6));
   
-  bricks::metaprogramming::combine<std::tuple<A, B, C>> c;
+  // As a sanity check, since `MUL` inherits from `ADD`,
+  // the following construct will work just fine.
+  EXPECT_EQ(15, MUL().ADD::operator()(ADD::TYPE(), 7, 8));
   
-  EXPECT_EQ("foo", c.foo());
-  EXPECT_EQ("bar", c.bar());
-  EXPECT_EQ("baz", c.baz());
+  // Using the simple combiner, that still uses `operator()`.
+  typedef bricks::metaprogramming::combine<std::tuple<NEG, ADD, MUL>> Arithmetics;
+  EXPECT_EQ(-1, Arithmetics()(NEG::TYPE(), 1));
+  EXPECT_EQ(5, Arithmetics()(ADD::TYPE(), 2, 3));
+  EXPECT_EQ(9, Arithmetics()(ADD::TYPE(), 2, 3, "4"));
+  EXPECT_EQ(30, Arithmetics()(MUL::TYPE(), 5, 6));
+  EXPECT_EQ(210, Arithmetics()(MUL::TYPE(), 5, 6, 7));
+  
+  // Using the dispatched methods.
+  EXPECT_EQ(42, UserFriendlyArithmetics().Neg(-42));
+  EXPECT_EQ(21, UserFriendlyArithmetics().Add(10, 11));
+  EXPECT_EQ(33, UserFriendlyArithmetics().Add(10, 11, "12"));
+  EXPECT_EQ(420, UserFriendlyArithmetics().Mul(20, 21));
+  EXPECT_EQ(9240, UserFriendlyArithmetics().Mul(20, 21, 22));
+    
+  // The following call will fail to compile,
+  // with a nice error message explaining
+  // that none of the `NEG`, `ADD` and `MUL`
+  // have division operation defined.
+  //
+  // UserFriendlyArithmetics().Div(100, 5);
 }
-  
+
+#if 0
   // Visitor.
 namespace visitor_unittest {
 using bricks::metaprogramming::visitor;
@@ -167,3 +253,4 @@ using namespace visitor_unittest;
   }
   EXPECT_EQ("b=102\nc=103\n", bar_baz.os.str());
 }
+#endif

--- a/template/mapreduce.h
+++ b/template/mapreduce.h
@@ -83,18 +83,6 @@ struct reduce_impl<F, std::tuple<T, TS...>> {
   typedef F<T, reduce<F, std::tuple<TS...>>> type;
 };
 
-// `combine<std::tuple<A, B, C>>` == a `struct` that combines all members and fields from `A`, `B` and `C`.
-template <typename A, typename B>
-struct multiple_inheritance_combiner_impl {
-  struct type : A, B {};
-};
-
-template <typename A, typename B>
-using multiple_inheritance_combiner = typename multiple_inheritance_combiner_impl<A, B>::type;
-
-template <typename TS>
-using combine = reduce<multiple_inheritance_combiner, TS>;
-
 }  // namespace metaprogramming
 }  // namespace bricks
 

--- a/template/metaprogramming.h
+++ b/template/metaprogramming.h
@@ -31,6 +31,6 @@ SOFTWARE.
 #include "pod.h"
 #include "is_tuple.h"
 #include "mapreduce.h"
-#include "visitor.h"
+#include "combine.h"
 
 #endif  // BRICKS_TEMPLATE_METAPROGRAMMING_H

--- a/template/visitor.h
+++ b/template/visitor.h
@@ -25,6 +25,12 @@ SOFTWARE.
 #ifndef BRICKS_TEMPLATE_VISITOR_H
 #define BRICKS_TEMPLATE_VISITOR_H
 
+#ifndef BRICKS_CHECK_HEADERS_MODE
+#error "`visitor.h` is being deprecated now."
+#endif
+
+#if 0
+
 #include <tuple>
 
 #include "is_tuple.h"
@@ -64,5 +70,7 @@ struct visitable : abstract_visitable<TYPELIST_AS_TUPLE> {
 
 }  // namespace metaprogramming
 }  // namespace bricks
+
+#endif
 
 #endif  // BRICKS_TEMPLATE_VISITOR_H


### PR DESCRIPTION
Magic part one of two: Combining methods without extra `using`-s and allowing exposing user-friendly names.

[To be] used in Yoda's client-facing API interface. Patience you must have.