### PR TITLE
RTTI-based call dispatching at pseudo-compile time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ EXPECT_EQ("(A+(B+C))",
 // Combine.
 struct NEG {
   // A simple way to differentiate logic by struct/class type
-  // is to provide a local, unique, symbol as the 1st param.
+  // is to use a helper local type as the 1st param in the signature.
   struct TYPE {};
   // Combine-able operations are defined as `operator()`.
   // Just because we need to pick one common name,
@@ -550,8 +550,8 @@ struct call_foo_bar {
   std::ostringstream os;
 } foo_bar;
 
-RTTIDynamicCall<std::tuple<A, B>>(pa, foo_bar);
-RTTIDynamicCall<std::tuple<A, B>>(pb, foo_bar);
+RTTIDynamicCall<std::tuple<A, B>>(*pa, foo_bar);
+RTTIDynamicCall<std::tuple<A, B>>(*pb, foo_bar);
 EXPECT_EQ("a=101\nb=102\n", foo_bar.os.str());
 
 struct call_bar_baz {
@@ -564,8 +564,8 @@ struct call_bar_baz {
   std::ostringstream os;
 } bar_baz;
 
-RTTIDynamicCall<std::tuple<B, C>>(pb, bar_baz);
-RTTIDynamicCall<std::tuple<B, C>>(pc, bar_baz);
+RTTIDynamicCall<std::tuple<B, C>>(*pb, bar_baz);
+RTTIDynamicCall<std::tuple<B, C>>(*pc, bar_baz);
 EXPECT_EQ("b=102\nc=103\n", bar_baz.os.str());
 // TODO(dkorolev): Test all the corner cases with exceptions, wrong base types, etc.
 ```

--- a/README.md
+++ b/README.md
@@ -502,25 +502,29 @@ EXPECT_EQ(9240, UserFriendlyArithmetics().Mul(20, 21, 22));
 // have division operation defined.
 //
 // UserFriendlyArithmetics().Div(100, 5);
-// Visitor.
-using typelist_ab = std::tuple<struct A, struct B>;
-using typelist_bc = std::tuple<struct B, struct C>;
-  
-struct A : visitable<typelist_ab, A> {
+
+// RTTI.
+struct BASE {
+  // Need a virtual base.
+  virtual ~BASE() = default;
+};
+
+struct A : virtual BASE {
   int a = 101;
   void foo(std::ostream& os) {
     os << "a=" << a << std::endl;
   }
 };
 
-struct B : visitable<typelist_ab, B>, visitable<typelist_bc, B> {
+// Inherit from `A` as well, just to show that we can.
+struct B : virtual A, virtual BASE {
   int b = 102;
   void bar(std::ostream& os) {
     os << "b=" << b << std::endl;
   }
 };
-
-struct C : visitable<typelist_bc, C> {
+// Even more "multiple" inheritance.
+struct C : virtual A, virtual B, virtual BASE {
   int c = 103;
   void baz(std::ostream& os) {
     os << "c=" << c << std::endl;
@@ -531,36 +535,39 @@ A a;
 B b;
 C c;
 
-struct call_foo_bar : visitor<typelist_ab> {
-  // Note that forgetting to handle one of `visit()` overrides will result in compile errors of two types:
-  // 1) overriding what is not `virtual`, thus attempting to operate on a parameter not from the type list, or
-  // 2) not overriding what should be overridden, thus attempting to instantiate the `visitor` that is abstract.
-  virtual void visit(A& a) override {
+BASE* pa = &a;
+// Explicit casts since `B` and `C` derive from `A` too.
+BASE* pb = static_cast<BASE*>(&b);
+BASE* pc = static_cast<BASE*>(&c);
+
+struct call_foo_bar {
+  void operator()(A& a) {
     a.foo(os);
   }
-  virtual void visit(B& b) override {
+  void operator()(B& b) {
     b.bar(os);
   }
   std::ostringstream os;
 } foo_bar;
-for (auto& it : std::vector<abstract_visitable<typelist_ab>*>({ &a, &b })) {
-  it->accept(foo_bar);
-}
+
+RTTIDynamicCall<std::tuple<A, B>>(pa, foo_bar);
+RTTIDynamicCall<std::tuple<A, B>>(pb, foo_bar);
 EXPECT_EQ("a=101\nb=102\n", foo_bar.os.str());
 
-struct call_bar_baz : visitor<typelist_bc> {
-  virtual void visit(B& b) override {
+struct call_bar_baz {
+  void operator()(B& b) {
     b.bar(os);
   }
-  virtual void visit(C& c) override {
+  void operator()(C& c) {
     c.baz(os);
   }
   std::ostringstream os;
 } bar_baz;
-for (auto& it : std::vector<abstract_visitable<typelist_bc>*>({ &b, &c })) {
-  it->accept(bar_baz);
-}
+
+RTTIDynamicCall<std::tuple<B, C>>(pb, bar_baz);
+RTTIDynamicCall<std::tuple<B, C>>(pc, bar_baz);
 EXPECT_EQ("b=102\nc=103\n", bar_baz.os.str());
+// TODO(dkorolev): Test all the corner cases with exceptions, wrong base types, etc.
 ```
 ## Run-Time Type Dispatching
 

--- a/mq/inmemory/consumer.h
+++ b/mq/inmemory/consumer.h
@@ -38,7 +38,7 @@ constexpr bool HasProcessMethodByPtr(char) {
 }
 
 template <typename T_MESSAGE>
-constexpr auto HasProcessMethodByPtr(int) -> decltype(std::declval<T_MESSAGE>()->Process(), bool()) {
+constexpr auto HasProcessMethodByPtr(int) -> decltype(std::declval<T_MESSAGE>() -> Process(), bool()) {
   return true;
 }
 

--- a/mq/inmemory/mq.h
+++ b/mq/inmemory/mq.h
@@ -236,8 +236,8 @@ class MMQ final {
       {
         // Then, export the message.
         // NO MUTEX REQUIRED.
-        mmq::ExportMessage(consumer_, std::move(circular_buffer_[tail].message_body),
-                           actually_dropped_messages);
+        mmq::ExportMessage(
+            consumer_, std::move(circular_buffer_[tail].message_body), actually_dropped_messages);
       }
 
       {

--- a/template/combine.h
+++ b/template/combine.h
@@ -32,14 +32,14 @@ namespace bricks {
 namespace metaprogramming {
 
 // `combine<std::tuple<A, B, C>>` == a `struct` that internally contains all `A`, `B` and `C`
-// via "has-a" inheritance, and exposes `operator()`, calls to which compile-time dispatched
+// via "has-a" inheritance, and exposes `operator()`, calls to which are dispatched in compile time
 // to the instances of `A`, `B` or `C` respectively, based on type signature.
 // No matching invocation signature will result in compile-time error, same as the case
 // of more than one invocation signature matching the call.
 
 template <typename T>
 struct dispatch {
-  T has_a_instance;
+  T instance;
 
   template <typename... XS>
   static constexpr bool sfinae(char) {
@@ -54,7 +54,7 @@ struct dispatch {
   template <typename... XS>
   typename std::enable_if<sfinae<XS...>(0), decltype(std::declval<T>()(std::declval<XS>()...))>::type
   operator()(XS... params) {
-    return has_a_instance(params...);
+    return instance(params...);
   }
 };
 

--- a/template/combine.h
+++ b/template/combine.h
@@ -1,0 +1,81 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BRICKS_TEMPLATE_COMBINE_H
+#define BRICKS_TEMPLATE_COMBINE_H
+
+#include <tuple>
+#include <utility>
+
+namespace bricks {
+namespace metaprogramming {
+
+// `combine<std::tuple<A, B, C>>` == a `struct` that internally contains all `A`, `B` and `C`
+// via "has-a" inheritance, and exposes `operator()`, calls to which compile-time dispatched
+// to the instances of `A`, `B` or `C` respectively, based on type signature.
+// No matching invocation signature will result in compile-time error, same as the case
+// of more than one invocation signature matching the call.
+
+template <typename T>
+struct dispatch {
+  T has_a_instance;
+
+  template <typename... XS>
+  static constexpr bool sfinae(char) {
+    return false;
+  }
+
+  template <typename... XS>
+  static constexpr auto sfinae(int) -> decltype(std::declval<T>()(std::declval<XS>()...), bool()) {
+    return true;
+  }
+
+  template <typename... XS>
+  typename std::enable_if<sfinae<XS...>(0), decltype(std::declval<T>()(std::declval<XS>()...))>::type
+  operator()(XS... params) {
+    return has_a_instance(params...);
+  }
+};
+
+template <typename T1, typename T2>
+struct inherit_from_both : T1, T2 {
+  using T1::operator();
+  using T2::operator();
+  // Note: clang++ passes `operator`-s through
+  // by default, whereas g++ requires `using`-s. --  D.K.
+};
+
+template <typename T>
+struct combine {};
+
+template <typename T>
+struct combine<std::tuple<T>> : dispatch<T> {};
+
+template <typename T, typename... TS>
+struct combine<std::tuple<T, TS...>> : inherit_from_both<dispatch<T>, combine<std::tuple<TS...>>> {};
+
+}  // namespace metaprogramming
+}  // namespace bricks
+
+#endif  // BRICKS_TEMPLATE_COMBINE_H

--- a/template/docu/docu_05metaprogramming_02.cc
+++ b/template/docu/docu_05metaprogramming_02.cc
@@ -180,77 +180,78 @@ TEST(TemplateMetaprogramming, Combine) {
   //
   // UserFriendlyArithmetics().Div(100, 5);
 }
-
-#if 0
-  // Visitor.
-namespace visitor_unittest {
-using bricks::metaprogramming::visitor;
-using bricks::metaprogramming::visitable;
-using bricks::metaprogramming::abstract_visitable;
-
-  using typelist_ab = std::tuple<struct A, struct B>;
-  using typelist_bc = std::tuple<struct B, struct C>;
-    
-  struct A : visitable<typelist_ab, A> {
+  
+  // RTTI.
+namespace rtti_unittest {
+  struct BASE {
+    // Need a virtual base.
+    virtual ~BASE() = default;
+  };
+  
+  struct A : virtual BASE {
     int a = 101;
     void foo(std::ostream& os) {
       os << "a=" << a << std::endl;
     }
   };
   
-  struct B : visitable<typelist_ab, B>, visitable<typelist_bc, B> {
+  // Inherit from `A` as well, just to show that we can.
+  struct B : virtual A, virtual BASE {
     int b = 102;
     void bar(std::ostream& os) {
       os << "b=" << b << std::endl;
     }
   };
-  
-  struct C : visitable<typelist_bc, C> {
+
+  // Even more "multiple" inheritance.
+  struct C : virtual A, virtual B, virtual BASE {
     int c = 103;
     void baz(std::ostream& os) {
       os << "c=" << c << std::endl;
     }
   };
-}  // namespace visitor_unittest
-  
-TEST(TemplateMetaprogramming, Visitor) {
-using namespace visitor_unittest;
+}  // namespace rtti_unittest
 
+TEST(TemplateMetaprogramming, RTTIDynamicCall) {
+using namespace rtti_unittest;
+using bricks::metaprogramming::RTTIDynamicCall;
+  
   A a;
   B b;
   C c;
   
-  struct call_foo_bar : visitor<typelist_ab> {
-    // Note that forgetting to handle one of `visit()` overrides will result in compile errors of two types:
-    // 1) overriding what is not `virtual`, thus attempting to operate on a parameter not from the type list, or
-    // 2) not overriding what should be overridden, thus attempting to instantiate the `visitor` that is abstract.
-    virtual void visit(A& a) override {
+  BASE* pa = &a;
+  // Explicit casts since `B` and `C` derive from `A` too.
+  BASE* pb = static_cast<BASE*>(&b);
+  BASE* pc = static_cast<BASE*>(&c);
+  
+  struct call_foo_bar {
+    void operator()(A& a) {
       a.foo(os);
     }
-    virtual void visit(B& b) override {
+    void operator()(B& b) {
       b.bar(os);
     }
     std::ostringstream os;
   } foo_bar;
-
-  for (auto& it : std::vector<abstract_visitable<typelist_ab>*>({ &a, &b })) {
-    it->accept(foo_bar);
-  }
+  
+  RTTIDynamicCall<std::tuple<A, B>>(pa, foo_bar);
+  RTTIDynamicCall<std::tuple<A, B>>(pb, foo_bar);
   EXPECT_EQ("a=101\nb=102\n", foo_bar.os.str());
   
-  struct call_bar_baz : visitor<typelist_bc> {
-    virtual void visit(B& b) override {
+  struct call_bar_baz {
+    void operator()(B& b) {
       b.bar(os);
     }
-    virtual void visit(C& c) override {
+    void operator()(C& c) {
       c.baz(os);
     }
     std::ostringstream os;
   } bar_baz;
-
-  for (auto& it : std::vector<abstract_visitable<typelist_bc>*>({ &b, &c })) {
-    it->accept(bar_baz);
-  }
+  
+  RTTIDynamicCall<std::tuple<B, C>>(pb, bar_baz);
+  RTTIDynamicCall<std::tuple<B, C>>(pc, bar_baz);
   EXPECT_EQ("b=102\nc=103\n", bar_baz.os.str());
+
+  // TODO(dkorolev): Test all the corner cases with exceptions, wrong base types, etc.
 }
-#endif

--- a/template/docu/docu_05metaprogramming_02.cc
+++ b/template/docu/docu_05metaprogramming_02.cc
@@ -91,7 +91,7 @@ template <typename T> int AsInt(T x) { return AsIntImpl<T>::DoIt(x); }
   // Combine.
   struct NEG {
     // A simple way to differentiate logic by struct/class type
-    // is to provide a local, unique, symbol as the 1st param.
+    // is to use a helper local type as the 1st param in the signature.
     struct TYPE {};
 
     // Combine-able operations are defined as `operator()`.

--- a/template/docu/docu_05metaprogramming_02.cc
+++ b/template/docu/docu_05metaprogramming_02.cc
@@ -220,10 +220,9 @@ using bricks::metaprogramming::RTTIDynamicCall;
   B b;
   C c;
   
-  BASE* pa = &a;
-  // Explicit casts since `B` and `C` derive from `A` too.
-  BASE* pb = static_cast<BASE*>(&b);
-  BASE* pc = static_cast<BASE*>(&c);
+  BASE& pa = a;
+  BASE& pb = b;
+  BASE& pc = c;
   
   struct call_foo_bar {
     void operator()(A& a) {
@@ -235,8 +234,8 @@ using bricks::metaprogramming::RTTIDynamicCall;
     std::ostringstream os;
   } foo_bar;
   
-  RTTIDynamicCall<std::tuple<A, B>>(*pa, foo_bar);
-  RTTIDynamicCall<std::tuple<A, B>>(*pb, foo_bar);
+  RTTIDynamicCall<std::tuple<A, B>>(pa, foo_bar);
+  RTTIDynamicCall<std::tuple<A, B>>(pb, foo_bar);
   EXPECT_EQ("a=101\nb=102\n", foo_bar.os.str());
   
   struct call_bar_baz {
@@ -249,9 +248,25 @@ using bricks::metaprogramming::RTTIDynamicCall;
     std::ostringstream os;
   } bar_baz;
   
-  RTTIDynamicCall<std::tuple<B, C>>(*pb, bar_baz);
-  RTTIDynamicCall<std::tuple<B, C>>(*pc, bar_baz);
+  RTTIDynamicCall<std::tuple<B, C>>(pb, bar_baz);
+  RTTIDynamicCall<std::tuple<B, C>>(pc, bar_baz);
   EXPECT_EQ("b=102\nc=103\n", bar_baz.os.str());
 
-  // TODO(dkorolev): Test all the corner cases with exceptions, wrong base types, etc.
+  struct call_foo_baz {
+    void operator()(A& a) {
+      a.foo(os);
+    }
+    void operator()(C& c) {
+      c.baz(os);
+    }
+    std::ostringstream os;
+  } foo_baz;
+  
+  std::unique_ptr<BASE> unique_a(new A());
+  std::unique_ptr<BASE> unique_c(new C());
+  RTTIDynamicCall<std::tuple<A, C>>(unique_a, foo_baz);
+  RTTIDynamicCall<std::tuple<A, C>>(unique_c, foo_baz);
+  EXPECT_EQ("a=101\nc=103\n", foo_baz.os.str());
+
+// TODO(dkorolev): Test all the corner cases with exceptions, wrong base types, etc.
 }

--- a/template/docu/docu_05metaprogramming_02.cc
+++ b/template/docu/docu_05metaprogramming_02.cc
@@ -83,19 +83,105 @@ TEST(TemplateMetaprogramming, Reduce) {
             (bricks::metaprogramming::reduce<concatenate_s, std::tuple<A, B, C>>::s()));
 }
     
+template <typename T> struct AsIntImpl {};
+template <> struct AsIntImpl<int> { static int DoIt(int x) { return x; } };
+template <> struct AsIntImpl<const char*> { static int DoIt(const char* s) { return atoi(s); } };
+template <typename T> int AsInt(T x) { return AsIntImpl<T>::DoIt(x); }
+
   // Combine.
+  struct NEG {
+    // A simple way to differentiate logic by struct/class type
+    // is to provide a local, unique, symbol as the 1st param.
+    struct TYPE {};
+
+    // Combine-able operations are defined as `operator()`.
+    // Just because we need to pick one common name,
+    // otherwise more `using`-s will be needed.
+    int operator()(TYPE, int a) { return -a; }
+  };
+  
+  struct ADD {
+    struct TYPE {};
+    int operator()(TYPE, int a, int b) { return a + b; }
+    // Prove that the method is instantiated at compile time.
+    template <typename T>
+    int operator()(TYPE, int a, int b, T c) {
+      return a + b + AsInt(c);
+    }
+  };
+  
+  // Since "has-a" is used instead of "is-a",
+  // mutual inheritance of underlying types
+  // is not a problem at all.
+  // Confirm this by making `MUL` inherit from `ADD`.
+  struct MUL : ADD {
+    struct TYPE {};
+    int operator()(TYPE, int a, int b) { return a * b; }
+    int operator()(TYPE, int a, int b, int c) { return a * b * c; }
+  };
+    
+  // User-friendly method names, internally dispatching calls via `operator()`.
+  // A good way to make sure new names appear in one place only, since
+  // using `using`-s would require writing them down at least twice each.
+  struct UserFriendlyArithmetics :
+      bricks::metaprogramming::combine<std::tuple<NEG, ADD, MUL>> {
+    int Neg(int x) {
+      return operator()(NEG::TYPE(), x);
+    }
+    template <typename... T>
+    int Add(T... xs) {
+      return operator()(ADD::TYPE(), xs...);
+    }
+    template <typename... T>
+    int Mul(T... xs) {
+      return operator()(MUL::TYPE(), xs...);
+    }
+    // The implementation for `Div()` is not provided,
+    // yet the code will compile until it's attempted to be used.
+    // (Unit tests and code coverage measurement FTW!)
+    template <typename... T>
+    int Div(T... xs) {
+      struct TypeForWhichThereIsNoImplemenation {};
+      return operator()(TypeForWhichThereIsNoImplemenation(),
+                        xs...);
+    }
+  };
+
 TEST(TemplateMetaprogramming, Combine) {
-  struct A { static std::string foo() { return "foo"; } };
-  struct B { static std::string bar() { return "bar"; } };
-  struct C { static std::string baz() { return "baz"; } };
+  EXPECT_EQ(1, NEG()(NEG::TYPE(), -1));
+  EXPECT_EQ(3, ADD()(ADD::TYPE(), 1, 2));
+  EXPECT_EQ(6, ADD()(ADD::TYPE(), 1, 2, "3"));
+  EXPECT_EQ(20, MUL()(MUL::TYPE(), 4, 5));
+  EXPECT_EQ(120, MUL()(MUL::TYPE(), 4, 5, 6));
   
-  bricks::metaprogramming::combine<std::tuple<A, B, C>> c;
+  // As a sanity check, since `MUL` inherits from `ADD`,
+  // the following construct will work just fine.
+  EXPECT_EQ(15, MUL().ADD::operator()(ADD::TYPE(), 7, 8));
   
-  EXPECT_EQ("foo", c.foo());
-  EXPECT_EQ("bar", c.bar());
-  EXPECT_EQ("baz", c.baz());
+  // Using the simple combiner, that still uses `operator()`.
+  typedef bricks::metaprogramming::combine<std::tuple<NEG, ADD, MUL>> Arithmetics;
+  EXPECT_EQ(-1, Arithmetics()(NEG::TYPE(), 1));
+  EXPECT_EQ(5, Arithmetics()(ADD::TYPE(), 2, 3));
+  EXPECT_EQ(9, Arithmetics()(ADD::TYPE(), 2, 3, "4"));
+  EXPECT_EQ(30, Arithmetics()(MUL::TYPE(), 5, 6));
+  EXPECT_EQ(210, Arithmetics()(MUL::TYPE(), 5, 6, 7));
+  
+  // Using the dispatched methods.
+  EXPECT_EQ(42, UserFriendlyArithmetics().Neg(-42));
+  EXPECT_EQ(21, UserFriendlyArithmetics().Add(10, 11));
+  EXPECT_EQ(33, UserFriendlyArithmetics().Add(10, 11, "12"));
+  EXPECT_EQ(420, UserFriendlyArithmetics().Mul(20, 21));
+  EXPECT_EQ(9240, UserFriendlyArithmetics().Mul(20, 21, 22));
+    
+  // The following call will fail to compile,
+  // with a nice error message explaining
+  // that none of the `NEG`, `ADD` and `MUL`
+  // have division operation defined.
+  //
+  // UserFriendlyArithmetics().Div(100, 5);
 }
-  
+
+#if 0
   // Visitor.
 namespace visitor_unittest {
 using bricks::metaprogramming::visitor;
@@ -167,3 +253,4 @@ using namespace visitor_unittest;
   }
   EXPECT_EQ("b=102\nc=103\n", bar_baz.os.str());
 }
+#endif

--- a/template/docu/docu_05metaprogramming_02.cc
+++ b/template/docu/docu_05metaprogramming_02.cc
@@ -235,8 +235,8 @@ using bricks::metaprogramming::RTTIDynamicCall;
     std::ostringstream os;
   } foo_bar;
   
-  RTTIDynamicCall<std::tuple<A, B>>(pa, foo_bar);
-  RTTIDynamicCall<std::tuple<A, B>>(pb, foo_bar);
+  RTTIDynamicCall<std::tuple<A, B>>(*pa, foo_bar);
+  RTTIDynamicCall<std::tuple<A, B>>(*pb, foo_bar);
   EXPECT_EQ("a=101\nb=102\n", foo_bar.os.str());
   
   struct call_bar_baz {
@@ -249,8 +249,8 @@ using bricks::metaprogramming::RTTIDynamicCall;
     std::ostringstream os;
   } bar_baz;
   
-  RTTIDynamicCall<std::tuple<B, C>>(pb, bar_baz);
-  RTTIDynamicCall<std::tuple<B, C>>(pc, bar_baz);
+  RTTIDynamicCall<std::tuple<B, C>>(*pb, bar_baz);
+  RTTIDynamicCall<std::tuple<B, C>>(*pc, bar_baz);
   EXPECT_EQ("b=102\nc=103\n", bar_baz.os.str());
 
   // TODO(dkorolev): Test all the corner cases with exceptions, wrong base types, etc.

--- a/template/mapreduce.h
+++ b/template/mapreduce.h
@@ -83,18 +83,6 @@ struct reduce_impl<F, std::tuple<T, TS...>> {
   typedef F<T, reduce<F, std::tuple<TS...>>> type;
 };
 
-// `combine<std::tuple<A, B, C>>` == a `struct` that combines all members and fields from `A`, `B` and `C`.
-template <typename A, typename B>
-struct multiple_inheritance_combiner_impl {
-  struct type : A, B {};
-};
-
-template <typename A, typename B>
-using multiple_inheritance_combiner = typename multiple_inheritance_combiner_impl<A, B>::type;
-
-template <typename TS>
-using combine = reduce<multiple_inheritance_combiner, TS>;
-
 }  // namespace metaprogramming
 }  // namespace bricks
 

--- a/template/metaprogramming.h
+++ b/template/metaprogramming.h
@@ -31,6 +31,6 @@ SOFTWARE.
 #include "pod.h"
 #include "is_tuple.h"
 #include "mapreduce.h"
-#include "visitor.h"
+#include "combine.h"
 
 #endif  // BRICKS_TEMPLATE_METAPROGRAMMING_H

--- a/template/metaprogramming.h
+++ b/template/metaprogramming.h
@@ -32,5 +32,6 @@ SOFTWARE.
 #include "is_tuple.h"
 #include "mapreduce.h"
 #include "combine.h"
+#include "rtti_dynamic_call.h"
 
 #endif  // BRICKS_TEMPLATE_METAPROGRAMMING_H

--- a/template/rtti_dynamic_call.h
+++ b/template/rtti_dynamic_call.h
@@ -78,13 +78,13 @@ struct SpecificUncastableTypeException : UncastableTypeException {
 
 template <typename BASE, typename F>
 struct RTTIDispatcherBase {
-  virtual void Handle(BASE*, F&&) const { throw SpecificUnhandledTypeException<BASE>(); }
+  virtual void Handle(BASE&, F&&) const { throw SpecificUnhandledTypeException<BASE>(); }
 };
 
 template <typename BASE, typename F, typename DERIVED>
 struct RTTIDispatcher : RTTIDispatcherBase<BASE, F> {
-  virtual void Handle(BASE* ptr, F&& f) const override {
-    DERIVED* derived = dynamic_cast<DERIVED*>(ptr);
+  virtual void Handle(BASE& ptr, F&& f) const override {
+    DERIVED* derived = dynamic_cast<DERIVED*>(&ptr);
     if (derived) {
       f(*derived);
     } else {
@@ -139,8 +139,8 @@ const RTTIDispatcherBase<BASE, F>* RTTIFindHandler(const std::type_info& type) {
 //                 that wraps all the types into pure virtual functions?
 //                 This way forgetting either of them would be a compile error.
 template <typename TYPELIST, typename BASE, typename F>
-void RTTIDynamicCall(BASE* ptr, F&& f) {
-  RTTIFindHandler<TYPELIST, BASE, F>(typeid(*ptr))->Handle(ptr, std::forward<F>(f));
+void RTTIDynamicCall(BASE& ptr, F&& f) {
+  RTTIFindHandler<TYPELIST, BASE, F>(typeid(ptr))->Handle(ptr, std::forward<F>(f));
 }
 
 }  // namespace metaprogramming

--- a/template/rtti_dynamic_call.h
+++ b/template/rtti_dynamic_call.h
@@ -148,6 +148,9 @@ void RTTIDynamicCall(std::unique_ptr<BASE>& ptr, F&& f) {
   RTTIDynamicCall<TYPELIST>(*ptr.get(), std::forward<F>(f));
 }
 
+// TODO(dkorolev): Consider whether RTTI-dispatched call might return a value.
+// TODO(dkorolev): Consider extending `RTTIDynamicCall` to support `const` inputs.
+
 }  // namespace metaprogramming
 }  // namespace bricks
 

--- a/template/rtti_dynamic_call.h
+++ b/template/rtti_dynamic_call.h
@@ -145,7 +145,7 @@ void RTTIDynamicCall(BASE& ptr, F&& f) {
 // A parital specialization for a `unique_ptr`.
 template <typename TYPELIST, typename BASE, typename F>
 void RTTIDynamicCall(std::unique_ptr<BASE>& ptr, F&& f) {
-  RTTIFindHandler<TYPELIST, BASE, F>(typeid(*ptr.get()))->Handle(*ptr.get(), std::forward<F>(f));
+  RTTIDynamicCall<TYPELIST>(*ptr.get(), std::forward<F>(f));
 }
 
 }  // namespace metaprogramming

--- a/template/rtti_dynamic_call.h
+++ b/template/rtti_dynamic_call.h
@@ -133,7 +133,6 @@ const RTTIDispatcherBase<BASE, F>* RTTIFindHandler(const std::type_info& type) {
 }
 
 // TODO(dkorolev): Should we support return value from these calls?
-// TODO(dkorolev): Should we firmly require a `unique_ptr<>`?
 // TODO(dkorolev): Non-const `PTR` OK?
 // TODO(dkorolev): Should we require `F` to derive from a special class
 //                 that wraps all the types into pure virtual functions?
@@ -141,6 +140,12 @@ const RTTIDispatcherBase<BASE, F>* RTTIFindHandler(const std::type_info& type) {
 template <typename TYPELIST, typename BASE, typename F>
 void RTTIDynamicCall(BASE& ptr, F&& f) {
   RTTIFindHandler<TYPELIST, BASE, F>(typeid(ptr))->Handle(ptr, std::forward<F>(f));
+}
+
+// A parital specialization for a `unique_ptr`.
+template <typename TYPELIST, typename BASE, typename F>
+void RTTIDynamicCall(std::unique_ptr<BASE>& ptr, F&& f) {
+  RTTIFindHandler<TYPELIST, BASE, F>(typeid(*ptr.get()))->Handle(*ptr.get(), std::forward<F>(f));
 }
 
 }  // namespace metaprogramming

--- a/template/rtti_dynamic_call.h
+++ b/template/rtti_dynamic_call.h
@@ -1,0 +1,149 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BRICKS_TEMPLATE_RTTI_DYNAMIC_CALL_H
+#define BRICKS_TEMPLATE_RTTI_DYNAMIC_CALL_H
+
+#include <string>
+#include <tuple>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+
+#include "is_tuple.h"
+
+#include "../exception.h"
+#include "../util/singleton.h"
+
+namespace bricks {
+namespace metaprogramming {
+
+struct RTTIException : Exception {
+  RTTIException() = delete;
+  explicit RTTIException(const std::string& s) : Exception(s) {}
+};
+
+struct UnlistedTypeException : RTTIException {
+  UnlistedTypeException() = delete;
+  explicit UnlistedTypeException(const std::string& s) : RTTIException(s) {}
+};
+
+template <typename T>
+struct SpecificUnlistedTypeException : UnlistedTypeException {
+  explicit SpecificUnlistedTypeException() : UnlistedTypeException(typeid(T).name()) {}
+};
+
+struct UnhandledTypeException : RTTIException {
+  UnhandledTypeException() = delete;
+  explicit UnhandledTypeException(const std::string& s) : RTTIException(s) {}
+};
+
+template <typename T>
+struct SpecificUnhandledTypeException : UnhandledTypeException {
+  explicit SpecificUnhandledTypeException() : UnhandledTypeException(typeid(T).name()) {}
+};
+
+struct UncastableTypeException : RTTIException {
+  UncastableTypeException() = delete;
+  explicit UncastableTypeException(const std::string& s) : RTTIException(s) {}
+};
+
+template <typename BASE, typename DERIVED>
+struct SpecificUncastableTypeException : UncastableTypeException {
+  explicit SpecificUncastableTypeException()
+      : UncastableTypeException(typeid(BASE).name() + std::string(" -> ") + typeid(DERIVED).name()) {}
+};
+
+template <typename BASE, typename F>
+struct RTTIDispatcherBase {
+  virtual void Handle(BASE*, F&&) const { throw SpecificUnhandledTypeException<BASE>(); }
+};
+
+template <typename BASE, typename F, typename DERIVED>
+struct RTTIDispatcher : RTTIDispatcherBase<BASE, F> {
+  virtual void Handle(BASE* ptr, F&& f) const override {
+    DERIVED* derived = dynamic_cast<DERIVED*>(ptr);
+    if (derived) {
+      f(*derived);
+    } else {
+      throw SpecificUncastableTypeException<BASE, DERIVED>();
+    }
+  }
+};
+
+template <typename BASE, typename F>
+using RTTIHandlersMap = std::unordered_map<std::type_index, std::unique_ptr<RTTIDispatcherBase<BASE, F>>>;
+
+template <typename TYPELIST, typename BASE, typename F>
+struct PopulateRTTIHandlers {};
+
+template <typename BASE, typename F>
+struct PopulateRTTIHandlers<std::tuple<>, BASE, F> {
+  static void DoIt(RTTIHandlersMap<BASE, F>&) {}
+};
+
+template <typename T, typename... TS, typename BASE, typename F>
+struct PopulateRTTIHandlers<std::tuple<T, TS...>, BASE, F> {
+  static void DoIt(RTTIHandlersMap<BASE, F>& map) {
+    // TODO(dkorolev): Check for duplicate types in input type list? Throw an exception?
+    map[std::type_index(typeid(T))].reset(new RTTIDispatcher<BASE, F, T>());
+    PopulateRTTIHandlers<std::tuple<TS...>, BASE, F>::DoIt(map);
+  }
+};
+
+template <typename TYPELIST, typename BASE, typename F>
+struct RTTIPopulatedHandlers {
+  static_assert(is_std_tuple<TYPELIST>::value, "");
+  RTTIHandlersMap<BASE, F> map;
+  RTTIPopulatedHandlers() { PopulateRTTIHandlers<TYPELIST, BASE, F>::DoIt(map); }
+};
+
+template <typename TYPELIST, typename BASE, typename F>
+const RTTIDispatcherBase<BASE, F>* RTTIFindHandler(const std::type_info& type) {
+  static_assert(is_std_tuple<TYPELIST>::value, "");
+  const RTTIHandlersMap<BASE, F>& map = ThreadLocalSingleton<RTTIPopulatedHandlers<TYPELIST, BASE, F>>().map;
+  const auto handler = map.find(std::type_index(type));
+  if (handler != map.end()) {
+    return handler->second.get();
+  } else {
+    throw SpecificUnlistedTypeException<BASE>();
+  }
+}
+
+// TODO(dkorolev): Should we support return value from these calls?
+// TODO(dkorolev): Should we firmly require a `unique_ptr<>`?
+// TODO(dkorolev): Non-const `PTR` OK?
+// TODO(dkorolev): Should we require `F` to derive from a special class
+//                 that wraps all the types into pure virtual functions?
+//                 This way forgetting either of them would be a compile error.
+template <typename TYPELIST, typename BASE, typename F>
+void RTTIDynamicCall(BASE* ptr, F&& f) {
+  RTTIFindHandler<TYPELIST, BASE, F>(typeid(*ptr))->Handle(ptr, std::forward<F>(f));
+}
+
+}  // namespace metaprogramming
+}  // namespace bricks
+
+#endif  // BRICKS_TEMPLATE_RTTI_DYNAMIC_CALL_H

--- a/template/visitor.h
+++ b/template/visitor.h
@@ -25,6 +25,12 @@ SOFTWARE.
 #ifndef BRICKS_TEMPLATE_VISITOR_H
 #define BRICKS_TEMPLATE_VISITOR_H
 
+#ifndef BRICKS_CHECK_HEADERS_MODE
+#error "`visitor.h` is being deprecated now."
+#endif
+
+#if 0
+
 #include <tuple>
 
 #include "is_tuple.h"
@@ -64,5 +70,7 @@ struct visitable : abstract_visitable<TYPELIST_AS_TUPLE> {
 
 }  // namespace metaprogramming
 }  // namespace bricks
+
+#endif
 
 #endif  // BRICKS_TEMPLATE_VISITOR_H


### PR DESCRIPTION
Yoda: You must unlearn what you have learned.

Bye-bye visitor.

[To be] used to support multiple types in a single Yoda instance.

Please review after https://github.com/KnowSheet/Bricks/pull/159.